### PR TITLE
MI-270: Encode LTI launch data and set it in a cookie

### DIFF
--- a/model/lti.go
+++ b/model/lti.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 import (
@@ -10,6 +13,8 @@ const (
 	LMS_TYPE_FIELD = "Type"
 
 	LMS_TYPE_EDX = "edx"
+
+	LTI_LAUNCH_DATA_COOKIE = "MMLTILAUNCHDATA"
 )
 
 type LMSOAuthSettings struct {

--- a/web/lti.go
+++ b/web/lti.go
@@ -1,11 +1,19 @@
 package web
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
+)
+
+const (
+	LTI_DATA_COOKIE = "MMLTIDATA"
 )
 
 func (w *Web) InitLti() {
@@ -19,7 +27,18 @@ func loginWithLti(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate request
+	valid := isRequestValid(c, r)
+	if !valid {
+		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	setLTIDataCookie(c, w, r)
+
+	http.Redirect(w, r, c.GetSiteURLHeader()+"/signup_lti", http.StatusFound)
+}
+
+func isRequestValid(c *Context, r *http.Request) bool {
 	lmss := c.App.Config().LTISettings.GetKnownLMSs()
 	ltiConsumerKey := r.FormValue("oauth_consumer_key")
 	var ltiConsumerSecret string
@@ -36,17 +55,49 @@ func loginWithLti(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if ltiConsumerSecret == "" {
 		mlog.Error("Consumer secret not found for consumer key: " + ltiConsumerKey)
-		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
-		return
+		return false
 	}
 
 	p := utils.NewProvider(ltiConsumerSecret, c.GetSiteURLHeader()+c.Path)
 	p.ConsumerKey = ltiConsumerKey
 	if ok, err := p.IsValid(r); err != nil || ok == false {
 		mlog.Error("Invalid LTI request: " + err.Error())
-		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
-		return
+		return false
 	}
 
-	http.Redirect(w, r, c.GetSiteURLHeader()+"/signup_lti", http.StatusFound)
+	return true
+}
+
+func encodeLTIRequest(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	form := make(map[string]string)
+	for key, value := range v {
+		form[key] = value[0]
+	}
+	res, err := json.Marshal(form)
+	if err != nil {
+		mlog.Error("Error in json.Marshal: " + err.Error())
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(string(res)))
+}
+
+func setLTIDataCookie(c *Context, w http.ResponseWriter, r *http.Request) {
+	r.ParseForm() // to populate r.Form
+	maxAge := 600 // 10 minutes
+	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
+	cookie := &http.Cookie{
+		Name:     LTI_DATA_COOKIE,
+		Value:    encodeLTIRequest(r.Form),
+		Path:     "/",
+		MaxAge:   maxAge,
+		Expires:  expiresAt,
+		Domain:   c.App.GetCookieDomain(),
+		HttpOnly: false,
+	}
+
+	http.SetCookie(w, cookie)
 }


### PR DESCRIPTION
#### Summary
Base64 Encode LTI launch data from LTI launch request and set it in a cookie.

#### Ticket Link
https://brightscout.atlassian.net/browse/MI-270

