### PR TITLE
LTI Auth Signup API (merge to develop)

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -240,7 +240,7 @@ func Init(a *app.App, root *mux.Router) *API {
 	api.InitScheme()
 	api.InitImage()
 	api.InitTermsOfService()
-	api.initLTI()
+	api.InitLTI()
 
 	root.Handle("/api/v4/{anything:.*}", http.HandlerFunc(api.Handle404))
 

--- a/api4/api.go
+++ b/api4/api.go
@@ -109,6 +109,8 @@ type Routes struct {
 	Webrtc *mux.Router // 'api/v4/webrtc'
 
 	TermsOfService *mux.Router // 'api/v4/terms_of_service
+
+	LTI *mux.Router // 'api/v4/lti'
 }
 
 type API struct {
@@ -207,6 +209,8 @@ func Init(a *app.App, root *mux.Router) *API {
 
 	api.BaseRoutes.TermsOfService = api.BaseRoutes.ApiRoot.PathPrefix("/terms_of_service").Subrouter()
 
+	api.BaseRoutes.LTI = api.BaseRoutes.ApiRoot.PathPrefix("/lti").Subrouter()
+
 	api.InitUser()
 	api.InitTeam()
 	api.InitChannel()
@@ -236,6 +240,7 @@ func Init(a *app.App, root *mux.Router) *API {
 	api.InitScheme()
 	api.InitImage()
 	api.InitTermsOfService()
+	api.initLTI()
 
 	root.Handle("/api/v4/{anything:.*}", http.HandlerFunc(api.Handle404))
 

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package api4
 
 import (

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -6,11 +6,12 @@ package api4
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/url"
+
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
-	"net/http"
-	"net/url"
 )
 
 func (api *API) initLTI() {

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -1,0 +1,92 @@
+package api4
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
+	"net/http"
+	"net/url"
+)
+
+func (api *API) initLTI() {
+	api.BaseRoutes.LTI.Handle("/signup", api.ApiHandler(signupWithLTI)).Methods("POST")
+}
+
+func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.App.Config().LTISettings.Enable {
+		mlog.Error("LTI signup request when LTI is disabled")
+		// TODO: add error message in en.json
+		// TODO: decide the correct error code here
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "1"}, "", http.StatusNotImplemented)
+		return
+	}
+
+
+	cookie, err := r.Cookie("MMLTIAUTHDATA")
+	if err != nil {
+		mlog.Error("Could't extract LTI auth data cookie: " + err.Error())
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "2"}, "", http.StatusBadRequest)
+		return
+	}
+
+	data, err := base64.StdEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		mlog.Error("Error occurred while decoding LTI launch data: " + err.Error())
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "3"}, "", http.StatusBadRequest)
+		return
+	}
+
+	ltiLaunchData := map[string]string{}
+	if err := json.Unmarshal(data, &ltiLaunchData); err != nil {
+		mlog.Error("Error occurred while unmarshaling LTI launch data: " + err.Error())
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "4"}, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// validate launch data
+	ltiLaunchDataRequest := buildLTIFormRequest(ltiLaunchData)
+	if !utils.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, c.App.Config().LTISettings.GetKnownLMSs(), ltiLaunchDataRequest) {
+		c.Err = model.NewAppError("loginWithLti", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "4"}, "", http.StatusBadRequest)
+		return
+	}
+
+	props := model.MapFromJson(r.Body)
+
+	// create user
+	user := &model.User{
+		Email: ltiLaunchData["lis_person_contact_email_primary"],
+		Username: ltiLaunchData["lis_person_sourcedid"],
+		FirstName: ltiLaunchData["lis_person_name_given"],
+		LastName: ltiLaunchData["lis_person_name_family"],
+		Position: ltiLaunchData["roles"],
+		Password: props["password"],
+		Props: model.StringMap{
+			"lti_user_id": ltiLaunchData["custom_user_id"],
+		},
+	}
+
+	if _, appErr := c.App.CreateUser(user); appErr != nil {
+		mlog.Error("Error occurred while creating new user: " + appErr.Error())
+		c.Err = model.NewAppError("loginWithLti", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "5"}, appErr.Error(), appErr.StatusCode)
+		return
+	}
+
+	// TODO: create required channels here
+	// TODO: add user to required channels here
+
+	w.WriteHeader(http.StatusOK)
+}
+
+
+func buildLTIFormRequest(ltiLaunchData map[string]string) *http.Request {
+	request := &http.Request{}
+	request.Form = url.Values{}
+
+	for k, v := range ltiLaunchData {
+		request.Form.Set(k, v)
+	}
+
+	return request
+}

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -26,7 +26,6 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
 	cookie, err := r.Cookie("MMLTIAUTHDATA")
 	if err != nil {
 		mlog.Error("Could't extract LTI auth data cookie: " + err.Error())
@@ -59,12 +58,12 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// create user
 	user := &model.User{
-		Email: ltiLaunchData["lis_person_contact_email_primary"],
-		Username: ltiLaunchData["lis_person_sourcedid"],
+		Email:     ltiLaunchData["lis_person_contact_email_primary"],
+		Username:  ltiLaunchData["lis_person_sourcedid"],
 		FirstName: ltiLaunchData["lis_person_name_given"],
-		LastName: ltiLaunchData["lis_person_name_family"],
-		Position: ltiLaunchData["roles"],
-		Password: props["password"],
+		LastName:  ltiLaunchData["lis_person_name_family"],
+		Position:  ltiLaunchData["roles"],
+		Password:  props["password"],
 		Props: model.StringMap{
 			"lti_user_id": ltiLaunchData["custom_user_id"],
 		},
@@ -81,7 +80,6 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 }
-
 
 func buildLTIFormRequest(ltiLaunchData map[string]string) *http.Request {
 	request := &http.Request{}

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 )
 
-func (api *API) initLTI() {
+func (api *API) InitLTI() {
 	api.BaseRoutes.LTI.Handle("/signup", api.ApiHandler(signupWithLTI)).Methods("POST")
 }
 
@@ -67,7 +67,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	// TODO: create required channels here
 	// TODO: add user to required channels here
 
-	w.WriteHeader(http.StatusOK)
+	ReturnStatusOK(w)
 }
 
 func addLaunchDataToForm(ltiLaunchData map[string]string, request *http.Request) *http.Request {

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -6,10 +6,11 @@ package api4
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/mattermost/mattermost-server/mlog"
-	"github.com/mattermost/mattermost-server/model"
 	"net/http"
 	"net/url"
+
+	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/model"
 )
 
 func (api *API) InitLTI() {
@@ -19,28 +20,28 @@ func (api *API) InitLTI() {
 func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !c.App.Config().LTISettings.Enable {
 		mlog.Error("LTI signup request when LTI is disabled")
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_disabled", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	cookie, err := r.Cookie(model.LTI_LAUNCH_DATA_COOKIE)
 	if err != nil {
 		mlog.Error("Could't extract LTI auth data cookie: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data.cookie_not_found", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.cookie_missing.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	data, err := base64.StdEncoding.DecodeString(cookie.Value)
 	if err != nil {
 		mlog.Error("Error occurred while decoding LTI launch data: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data.decoding_failed", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.decoding.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	ltiLaunchData := map[string]string{}
 	if err := json.Unmarshal(data, &ltiLaunchData); err != nil {
 		mlog.Error("Error occurred while unmarshaling LTI launch data: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data.unmarshaling_failed", nil, err.Error(), http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.unmarshaling.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -49,7 +50,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	lms := c.App.GetLMSToUse(consumerKey)
 
 	if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_launch_data.validation_failed", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.validation.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -61,7 +61,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if appErr != nil {
 		mlog.Error("Error occurred while creating LTI user: " + appErr.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.create_user_failed", nil, appErr.Error(), appErr.StatusCode)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.create_user.app_error", nil, appErr.Error(), appErr.StatusCode)
 		return
 	}
 

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -23,35 +23,35 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		mlog.Error("LTI signup request when LTI is disabled")
 		// TODO: add error message in en.json
 		// TODO: decide the correct error code here
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "1"}, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_disabled", nil, "", http.StatusNotImplemented)
 		return
 	}
 
-	cookie, err := r.Cookie("MMLTIAUTHDATA")
+	cookie, err := r.Cookie("MMLTILAUNCHDATA")
 	if err != nil {
 		mlog.Error("Could't extract LTI auth data cookie: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "2"}, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data_cookie_not_found", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	data, err := base64.StdEncoding.DecodeString(cookie.Value)
 	if err != nil {
 		mlog.Error("Error occurred while decoding LTI launch data: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "3"}, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data.decoding_failed", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	ltiLaunchData := map[string]string{}
 	if err := json.Unmarshal(data, &ltiLaunchData); err != nil {
 		mlog.Error("Error occurred while unmarshaling LTI launch data: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "4"}, err.Error(), http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data.unmarshaling_failed", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// validate launch data
 	ltiLaunchDataRequest := buildLTIFormRequest(ltiLaunchData)
 	if !utils.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, c.App.Config().LTISettings.GetKnownLMSs(), ltiLaunchDataRequest) {
-		c.Err = model.NewAppError("loginWithLti", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "4"}, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("loginWithLti", "api.lti.signup.app_error.lti_launch_data.validation_failed", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -72,7 +72,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if _, appErr := c.App.CreateUser(user); appErr != nil {
 		mlog.Error("Error occurred while creating new user: " + appErr.Error())
-		c.Err = model.NewAppError("loginWithLti", "api.lti.signup.app_error", map[string]interface{}{"ErrorCode": "5"}, appErr.Error(), appErr.StatusCode)
+		c.Err = model.NewAppError("loginWithLti", "api.lti.signup.app_error.create_user.failed", nil, appErr.Error(), appErr.StatusCode)
 		return
 	}
 

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -49,7 +49,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	consumerKey := ltiLaunchData["oauth_consumer_key"]
 	lms := c.App.GetLMSToUse(consumerKey)
 
-	if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
+	if c.App.Config().LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.validation.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -26,7 +26,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(model.LTI_LAUNCH_DATA_COOKIE)
 	if err != nil {
 		mlog.Error("Could't extract LTI auth data cookie: " + err.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data_cookie_not_found", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_data.cookie_not_found", nil, "", http.StatusBadRequest)
 		return
 	}
 

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -6,11 +6,10 @@ package api4
 import (
 	"encoding/base64"
 	"encoding/json"
-	"net/http"
-	"net/url"
-
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
+	"net/http"
+	"net/url"
 )
 
 func (api *API) initLTI() {
@@ -49,7 +48,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	consumerKey := ltiLaunchData["oauth_consumer_key"]
 	lms := c.App.GetLMSToUse(consumerKey)
 
-	if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, addLaunchDataToForm(ltiLaunchData, r)) {
+	if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.app_error.lti_launch_data.validation_failed", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/api4/lti_test.go
+++ b/api4/lti_test.go
@@ -3,8 +3,9 @@ package api4
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSignupWithLTI(t *testing.T) {
@@ -13,26 +14,26 @@ func TestSignupWithLTI(t *testing.T) {
 	Client := th.Client
 
 	launchData := map[string]string{
-		"oauth_consumer_key":                     "canvas-emeritus_5863",
-		"oauth_signature_method":                 "HMAC-SHA1",
-		"oauth_version":                          "1.0",
-		"context_id":                             "context-id",
-		"context_label":                          "Test",
-		"context_title":                          "Testing Various Integrations",
-		"custom_cohort_name":                     "Cohort A",
-		"custom_cohort_id":                       "99",
-		"custom_team_name":                       "Team1",
-		"custom_team_id":                         "99",
-		"custom_user_id":                         "999",
-		"lis_person_contact_email_primary":       "foo@bar.com",
-		"lis_person_name_family":                 "Bar",
-		"lis_person_name_full":                   "Foo Bar",
-		"lis_person_name_given":                  "Foo",
-		"lis_person_sourcedid":                   "foo",
-		"lti_version":                            "LTI-1p0",
-		"roles":                                  "Instructor",
-		"user_id":                                "user-id",
-		"oauth_signature":                        "A1YyNs3Gdea/6g+Q2MpPkUfQB2I=",
+		"oauth_consumer_key":               "canvas-emeritus_5863",
+		"oauth_signature_method":           "HMAC-SHA1",
+		"oauth_version":                    "1.0",
+		"context_id":                       "context-id",
+		"context_label":                    "Test",
+		"context_title":                    "Testing Various Integrations",
+		"custom_cohort_name":               "Cohort A",
+		"custom_cohort_id":                 "99",
+		"custom_team_name":                 "Team1",
+		"custom_team_id":                   "99",
+		"custom_user_id":                   "999",
+		"lis_person_contact_email_primary": "foo@bar.com",
+		"lis_person_name_family":           "Bar",
+		"lis_person_name_full":             "Foo Bar",
+		"lis_person_name_given":            "Foo",
+		"lis_person_sourcedid":             "foo",
+		"lti_version":                      "LTI-1p0",
+		"roles":                            "Instructor",
+		"user_id":                          "user-id",
+		"oauth_signature":                  "A1YyNs3Gdea/6g+Q2MpPkUfQB2I=",
 	}
 	bytes, err := json.Marshal(launchData)
 	assert.Nil(t, err)

--- a/api4/lti_test.go
+++ b/api4/lti_test.go
@@ -1,0 +1,46 @@
+package api4
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSignupWithLTI(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	Client := th.Client
+
+	launchData := map[string]string{
+		"oauth_consumer_key":                     "canvas-emeritus_5863",
+		"oauth_signature_method":                 "HMAC-SHA1",
+		"oauth_version":                          "1.0",
+		"context_id":                             "context-id",
+		"context_label":                          "Test",
+		"context_title":                          "Testing Various Integrations",
+		"custom_cohort_name":                     "Cohort A",
+		"custom_cohort_id":                       "99",
+		"custom_team_name":                       "Team1",
+		"custom_team_id":                         "99",
+		"custom_user_id":                         "999",
+		"lis_person_contact_email_primary":       "foo@bar.com",
+		"lis_person_name_family":                 "Bar",
+		"lis_person_name_full":                   "Foo Bar",
+		"lis_person_name_given":                  "Foo",
+		"lis_person_sourcedid":                   "foo",
+		"lti_version":                            "LTI-1p0",
+		"roles":                                  "Instructor",
+		"user_id":                                "user-id",
+		"oauth_signature":                        "A1YyNs3Gdea/6g+Q2MpPkUfQB2I=",
+	}
+	bytes, err := json.Marshal(launchData)
+	assert.Nil(t, err)
+
+	cookie := base64.StdEncoding.EncodeToString(bytes)
+	Client.HttpHeader["Cookie"] = "MMLTIAUTHDATA=" + cookie
+
+	resp := Client.SignupLTIUser("pa$$word")
+
+	CheckNoError(t, resp)
+}

--- a/api4/lti_test.go
+++ b/api4/lti_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package api4
 
 import (
@@ -14,7 +17,7 @@ func TestSignupWithLTI(t *testing.T) {
 	Client := th.Client
 
 	launchData := map[string]string{
-		"oauth_consumer_key":               "canvas-emeritus_5863",
+		"oauth_consumer_key":               "edx-appsembler-test_5345",
 		"oauth_signature_method":           "HMAC-SHA1",
 		"oauth_version":                    "1.0",
 		"context_id":                       "context-id",
@@ -33,13 +36,13 @@ func TestSignupWithLTI(t *testing.T) {
 		"lti_version":                      "LTI-1p0",
 		"roles":                            "Instructor",
 		"user_id":                          "user-id",
-		"oauth_signature":                  "A1YyNs3Gdea/6g+Q2MpPkUfQB2I=",
+		"oauth_signature":                  "UjaH+n/SxA4DvbMZPNxpLKKRga4=",
 	}
 	bytes, err := json.Marshal(launchData)
 	assert.Nil(t, err)
 
 	cookie := base64.StdEncoding.EncodeToString(bytes)
-	Client.HttpHeader["Cookie"] = "MMLTIAUTHDATA=" + cookie
+	Client.HttpHeader["Cookie"] = "MMLTILAUNCHDATA=" + cookie
 
 	resp := Client.SignupLTIUser("pa$$word")
 

--- a/app/lti.go
+++ b/app/lti.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package app
 
 import (
@@ -6,7 +9,7 @@ import (
 
 func (a *App) GetLMSToUse(consumerKey string) model.LMS {
 	for _, lms := range a.Config().LTISettings.GetKnownLMSs() {
-		if lms.GetOAuth().ConsumerKey == consumerKey  {
+		if lms.GetOAuth().ConsumerKey == consumerKey {
 			return lms
 		}
 	}

--- a/app/lti.go
+++ b/app/lti.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func (a *App) GetLMSToUse(consumerKey string) model.LMS {
+	for _, lms := range a.Config().LTISettings.GetKnownLMSs() {
+		if lms.GetOAuth().ConsumerKey == consumerKey  {
+			return lms
+		}
+	}
+	return nil
+}

--- a/config/config-dev.json
+++ b/config/config-dev.json
@@ -82,7 +82,7 @@
         "EnableOpenServer": false,
         "EnableUserDeactivation": false,
         "RestrictCreationToDomains": "",
-        "EnableCustomBrand": true,
+        "EnableCustomBrand": false,
         "CustomBrandText": "Your course collaboration platform.\nConnected teams have better outcomes.",
         "CustomDescriptionText": "Your course collaboration platform. Connected teams have better outcomes.",
         "RestrictDirectMessage": "any",

--- a/config/config-dev.json
+++ b/config/config-dev.json
@@ -75,16 +75,16 @@
         "EnableEmailInvitations": false
     },
     "TeamSettings": {
-        "SiteName": "Mattermost",
+        "SiteName": "Riff Edu",
         "MaxUsersPerTeam": 50,
         "EnableTeamCreation": true,
         "EnableUserCreation": true,
         "EnableOpenServer": false,
         "EnableUserDeactivation": false,
         "RestrictCreationToDomains": "",
-        "EnableCustomBrand": false,
-        "CustomBrandText": "",
-        "CustomDescriptionText": "",
+        "EnableCustomBrand": true,
+        "CustomBrandText": "Your course collaboration platform.\nConnected teams have better outcomes.",
+        "CustomDescriptionText": "Your course collaboration platform. Connected teams have better outcomes.",
         "RestrictDirectMessage": "any",
         "RestrictTeamInvite": "all",
         "RestrictPublicChannelManagement": "all",
@@ -328,6 +328,7 @@
     },
     "LTISettings": {
         "Enable": true,
+        "EnableSignatureValidation": false,
         "Lmss": [
             {
                 "Name": "Emeritus",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1206,39 +1206,39 @@
   },
   {
     "id": "api.lti.login.disabled.app_error",
-    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-1"
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-01"
   },
   {
     "id": "api.lti.login.parse.app_error",
-    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-2"
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-02"
   },
   {
     "id": "api.lti.login.validation.app_error",
-    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-3"
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-03"
   },
   {
     "id": "api.lti.login.encoding.app_error",
-    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-4"
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-04"
   },
   {
     "id": "api.lti.login.marshalling.app_error",
-    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-5"
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-05"
   },
   {
     "id": "api.lti.signup.disabled.app_error",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-6"
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-06"
   },
   {
     "id": "api.lti.signup.cookie_missing.app_error",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-7"
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-07"
   },
   {
     "id": "api.lti.signup.decoding.app_error",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-8"
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-08"
   },
   {
     "id": "api.lti.signup.unmarshaling.app_error",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-9"
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-09"
   },
   {
     "id": "api.lti.signup.validation.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1209,11 +1209,15 @@
     "translation": "There was an error with your login credentials. Please try again or contact your system administrator."
   },
   {
+    "id": "api.lti.login.cookie.set_error",
+    "translation": "There was an error with your login credentials. Please try again or contact your system administrator. Error code LTI-8"
+  },
+  {
     "id": "api.lti.signup.app_error.lti_disabled",
     "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-1"
   },
   {
-    "id": "api.lti.signup.app_error.lti_data_cookie_not_found",
+    "id": "api.lti.signup.app_error.lti_data.cookie_not_found",
     "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-2"
   },
   {
@@ -1231,6 +1235,10 @@
   {
     "id": "api.lti.signup.app_error.create_user.failed",
     "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-6"
+  },
+  {
+    "id": "api.lti.signup.app_error.form.parse_failed",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-7"
   },
   {
     "id": "api.oauth.allow_oauth.redirect_callback.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1205,40 +1205,48 @@
     "translation": "New format for the client license is not supported yet. Please specify format=old in the query string."
   },
   {
-    "id": "api.lti.login.app_error",
-    "translation": "There was an error with your login credentials. Please try again or contact your system administrator."
+    "id": "api.lti.login.disabled.app_error",
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-1"
   },
   {
-    "id": "api.lti.login.cookie.set_error",
-    "translation": "There was an error with your login credentials. Please try again or contact your system administrator. Error code LTI-8"
+    "id": "api.lti.login.parse.app_error",
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-2"
   },
   {
-    "id": "api.lti.signup.app_error.lti_disabled",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-1"
+    "id": "api.lti.login.validation.app_error",
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-3"
   },
   {
-    "id": "api.lti.signup.app_error.lti_data.cookie_not_found",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-2"
+    "id": "api.lti.login.encoding.app_error",
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-4"
   },
   {
-    "id": "api.lti.signup.app_error.lti_data.decoding_failed",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-3"
+    "id": "api.lti.login.marshalling.app_error",
+    "translation": "There was an error with LTI login attempt. Please try again or contact your system administrator. Error code LTI-5"
   },
   {
-    "id": "api.lti.signup.app_error.lti_data.unmarshaling_failed",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-4"
-  },
-  {
-    "id": "api.lti.signup.app_error.lti_launch_data.validation_failed",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-5"
-  },
-  {
-    "id": "api.lti.signup.app_error.create_user.failed",
+    "id": "api.lti.signup.disabled.app_error",
     "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-6"
   },
   {
-    "id": "api.lti.signup.app_error.form.parse_failed",
+    "id": "api.lti.signup.cookie_missing.app_error",
     "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-7"
+  },
+  {
+    "id": "api.lti.signup.decoding.app_error",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-8"
+  },
+  {
+    "id": "api.lti.signup.unmarshaling.app_error",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-9"
+  },
+  {
+    "id": "api.lti.signup.validation.app_error",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-10"
+  },
+  {
+    "id": "api.lti.signup.create_user.app_error",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-11"
   },
   {
     "id": "api.oauth.allow_oauth.redirect_callback.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1209,8 +1209,28 @@
     "translation": "There was an error with your login credentials. Please try again or contact your system administrator."
   },
   {
-    "id": "api.lti.signup.app_error",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-{{.ErrorCode}}"
+    "id": "api.lti.signup.app_error.lti_disabled",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-1"
+  },
+  {
+    "id": "api.lti.signup.app_error.lti_data_cookie_not_found",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-2"
+  },
+  {
+    "id": "api.lti.signup.app_error.lti_data.decoding_failed",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-3"
+  },
+  {
+    "id": "api.lti.signup.app_error.lti_data.unmarshaling_failed",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-4"
+  },
+  {
+    "id": "api.lti.signup.app_error.lti_launch_data.validation_failed",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-5"
+  },
+  {
+    "id": "api.lti.signup.app_error.create_user.failed",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-6"
   },
   {
     "id": "api.oauth.allow_oauth.redirect_callback.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1209,6 +1209,10 @@
     "translation": "There was an error with your login credentials. Please try again or contact your system administrator."
   },
   {
+    "id": "api.lti.signup.app_error",
+    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-{{.ErrorCode}}"
+  },
+  {
     "id": "api.oauth.allow_oauth.redirect_callback.app_error",
     "translation": "invalid_request: Supplied redirect_uri did not match registered callback_url"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -3846,6 +3846,7 @@ func (c *Client4) SignupLTIUser(password string) *Response {
 	url := c.GetSignupWithLTIRoute()
 
 	data := map[string]string{"password": password}
+
 	if r, err := c.DoApiPost(url, MapToJson(data)); err != nil {
 		return BuildErrorResponse(r, err)
 	} else {

--- a/model/client4.go
+++ b/model/client4.go
@@ -409,6 +409,10 @@ func (c *Client4) GetTermsOfServiceRoute() string {
 	return "/terms_of_service"
 }
 
+func (c *Client4) GetSignupWithLTIRoute() string {
+	return "/lti/signup"
+}
+
 func (c *Client4) DoApiGet(url string, etag string) (*http.Response, *AppError) {
 	return c.DoApiRequest(http.MethodGet, c.ApiUrl+url, "", etag)
 }
@@ -3835,5 +3839,16 @@ func (c *Client4) CreateTermsOfService(text, userId string) (*TermsOfService, *R
 	} else {
 		defer closeBody(r)
 		return TermsOfServiceFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+func (c *Client4) SignupLTIUser(password string) *Response {
+	url := c.GetSignupWithLTIRoute()
+
+	data := map[string]string{"password": password}
+	if r, err := c.DoApiPost(url, MapToJson(data)); err != nil {
+		return BuildErrorResponse(r, err)
+	} else {
+		return BuildResponse(r)
 	}
 }

--- a/model/edx.go
+++ b/model/edx.go
@@ -41,3 +41,17 @@ func (e *EdxLMS) GetValidateLTIRequest() bool {
 func (e *EdxLMS) ValidateLTIRequest(url string, request *http.Request) bool {
 	return baseValidateLTIRequest(e.OAuth.ConsumerSecret, e.OAuth.ConsumerKey, url, request)
 }
+
+func (e *EdxLMS) BuildUser(launchData map[string]string, password string) *User {
+	return &User{
+		Email:     launchData["lis_person_contact_email_primary"],
+		Username:  launchData["lis_person_sourcedid"],
+		FirstName: launchData["lis_person_name_given"],
+		LastName:  launchData["lis_person_name_family"],
+		Position:  launchData["roles"],
+		Password:  password,
+		Props: StringMap{
+			"lti_user_id": launchData["custom_user_id"],
+		},
+	}
+}

--- a/model/edx.go
+++ b/model/edx.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"net/http"
+)
+
+type EdxChannel struct {
+	CourseType   string
+	NameProperty string
+	IDProperty   string
+}
+
+type EdxUserChannelsSettings struct {
+	Type        string
+	ChannelList []EdxChannel
+}
+
+type EdxLMS struct {
+	Name  string
+	Type  string
+	OAuth LMSOAuthSettings
+	UserChannels EdxUserChannelsSettings
+}
+
+func (e *EdxLMS) GetName() string {
+	return e.Name
+}
+
+func (e *EdxLMS) GetType() string {
+	return e.Type
+}
+
+func (e *EdxLMS) GetOAuth() LMSOAuthSettings {
+	return e.OAuth
+}
+
+func (e *EdxLMS) GetValidateLTIRequest() bool {
+	return true
+}
+
+func (e *EdxLMS) ValidateLTIRequest(url string, request *http.Request) bool {
+	return baseValidateLTIRequest(e.OAuth.ConsumerSecret, e.OAuth.ConsumerKey, url, request)
+}

--- a/model/edx.go
+++ b/model/edx.go
@@ -57,7 +57,7 @@ func (e *EdxLMS) ValidateLTIRequest(url string, request *http.Request) bool {
 func (e *EdxLMS) BuildUser(launchData map[string]string, password string) *User {
 	return &User{
 		Email:     launchData[launchDataEmailKey],
-		Username:  launchData[launchDataUsernameKey],
+		Username:  transformLTIUsername(launchData[launchDataUsernameKey]),
 		FirstName: launchData[launchDataFirstNameKey],
 		LastName:  launchData[launchDataLastNameKey],
 		Position:  launchData[launchDataPositionKey],

--- a/model/edx.go
+++ b/model/edx.go
@@ -7,6 +7,15 @@ import (
 	"net/http"
 )
 
+const (
+	launchDataEmailKey     = "lis_person_contact_email_primary"
+	launchDataUsernameKey  = "lis_person_sourcedid"
+	launchDataFirstNameKey = "lis_person_name_given"
+	launchDataLastNameKey  = "lis_person_name_family"
+	launchDataPositionKey  = "roles"
+	launchDataLTIUserIdKey = "custom_user_id"
+)
+
 type EdxChannel struct {
 	CourseType   string
 	NameProperty string
@@ -47,14 +56,14 @@ func (e *EdxLMS) ValidateLTIRequest(url string, request *http.Request) bool {
 
 func (e *EdxLMS) BuildUser(launchData map[string]string, password string) *User {
 	return &User{
-		Email:     launchData["lis_person_contact_email_primary"],
-		Username:  launchData["lis_person_sourcedid"],
-		FirstName: launchData["lis_person_name_given"],
-		LastName:  launchData["lis_person_name_family"],
-		Position:  launchData["roles"],
+		Email:     launchData[launchDataEmailKey],
+		Username:  launchData[launchDataUsernameKey],
+		FirstName: launchData[launchDataFirstNameKey],
+		LastName:  launchData[launchDataLastNameKey],
+		Position:  launchData[launchDataPositionKey],
 		Password:  password,
 		Props: StringMap{
-			"lti_user_id": launchData["custom_user_id"],
+			"lti_user_id": launchData[launchDataLTIUserIdKey],
 		},
 	}
 }

--- a/model/edx.go
+++ b/model/edx.go
@@ -63,7 +63,7 @@ func (e *EdxLMS) BuildUser(launchData map[string]string, password string) *User 
 		Position:  launchData[launchDataPositionKey],
 		Password:  password,
 		Props: StringMap{
-			"lti_user_id": launchData[launchDataLTIUserIdKey],
+			LTI_USER_ID_PROP_KEY : launchData[launchDataLTIUserIdKey],
 		},
 	}
 }

--- a/model/edx.go
+++ b/model/edx.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 import (
@@ -16,9 +19,9 @@ type EdxUserChannelsSettings struct {
 }
 
 type EdxLMS struct {
-	Name  string
-	Type  string
-	OAuth LMSOAuthSettings
+	Name         string
+	Type         string
+	OAuth        LMSOAuthSettings
 	UserChannels EdxUserChannelsSettings
 }
 

--- a/model/lti.go
+++ b/model/lti.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 import (

--- a/model/lti.go
+++ b/model/lti.go
@@ -27,6 +27,7 @@ type LMS interface {
 	GetType() string
 	GetOAuth() LMSOAuthSettings
 	ValidateLTIRequest(url string, request *http.Request) bool
+	BuildUser(launchData map[string]string, password string) *User
 }
 
 type LTISettings struct {

--- a/model/lti.go
+++ b/model/lti.go
@@ -13,6 +13,8 @@ const (
 	LMS_TYPE_FIELD = "Type"
 
 	LMS_TYPE_EDX = "edx"
+
+	LTI_LAUNCH_DATA_COOKIE = "MMLTILAUNCHDATA"
 )
 
 type LMSOAuthSettings struct {

--- a/model/lti.go
+++ b/model/lti.go
@@ -15,6 +15,8 @@ const (
 	LMS_TYPE_EDX = "edx"
 
 	LTI_LAUNCH_DATA_COOKIE = "MMLTILAUNCHDATA"
+
+	LTI_USER_ID_PROP_KEY = "lti_user_id"
 )
 
 type LMSOAuthSettings struct {

--- a/model/lti.go
+++ b/model/lti.go
@@ -5,8 +5,9 @@ package model
 
 import (
 	"encoding/json"
-	"github.com/mattermost/mattermost-server/mlog"
 	"net/http"
+
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 const (
@@ -33,8 +34,9 @@ type LMS interface {
 }
 
 type LTISettings struct {
-	Enable bool
-	LMSs   []interface{}
+	Enable                    bool
+	EnableSignatureValidation bool
+	LMSs                      []interface{}
 }
 
 // GetKnownLMSs can be used to extract a slice of known LMSs from LTI settings

--- a/model/lti.go
+++ b/model/lti.go
@@ -70,3 +70,15 @@ func baseValidateLTIRequest(consumerSecret, consumerKey, url string, request *ht
 
 	return true
 }
+
+func transformLTIUsername(ltiUsername string) string {
+	mattermostUsername := ""
+
+	for _, c := range ltiUsername {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' {
+			mattermostUsername += string(c)
+		}
+	}
+
+	return mattermostUsername
+}

--- a/model/provider.go
+++ b/model/provider.go
@@ -28,9 +28,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"github.com/mattermost/mattermost-server/mlog"
-	"github.com/mattermost/mattermost-server/model"
 )
 
 const (
@@ -273,33 +270,4 @@ func nonce() string {
 		atomic.CompareAndSwapUint64(&nonceCounter, 1, n)
 	}
 	return strconv.FormatUint(n, 16)
-}
-
-func ValidateLTIRequest(url string, lmss []interface{}, r *http.Request) bool {
-	ltiConsumerKey := r.FormValue("oauth_consumer_key")
-	var ltiConsumerSecret string
-
-	for _, val := range lmss {
-		// TODO: Figure out a better way to find consumer secret for multiple LMSs
-		if lms, ok := val.(model.EdxLMSSettings); ok {
-			if lms.OAuth.ConsumerKey == ltiConsumerKey {
-				ltiConsumerSecret = lms.OAuth.ConsumerSecret
-				break
-			}
-		}
-	}
-
-	if ltiConsumerSecret == "" {
-		mlog.Error("Consumer secret not found for consumer key: " + ltiConsumerKey)
-		return false
-	}
-
-	p := NewProvider(ltiConsumerSecret, url)
-	p.ConsumerKey = ltiConsumerKey
-	if ok, err := p.IsValid(r); err != nil || ok == false {
-		mlog.Error("Invalid LTI request: " + err.Error())
-		return false
-	}
-
-	return true
 }

--- a/model/provider.go
+++ b/model/provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-package utils
+package model
 
 // LTI Tools from: https://github.com/jordic/lti
 // OAuth Tools from: github.com/daemonl/go_oauth
@@ -275,8 +275,6 @@ func nonce() string {
 	return strconv.FormatUint(n, 16)
 }
 
-// ValidateLTIRequest is used to validate an LTI request by iterating through known lmss
-// to find the consumer secret for consumer key and using that to match oauth signature
 func ValidateLTIRequest(url string, lmss []interface{}, r *http.Request) bool {
 	ltiConsumerKey := r.FormValue("oauth_consumer_key")
 	var ltiConsumerSecret string

--- a/model/provider_test.go
+++ b/model/provider_test.go
@@ -1,4 +1,4 @@
-package utils
+package model
 
 import (
 	"fmt"

--- a/utils/lti.go
+++ b/utils/lti.go
@@ -275,6 +275,8 @@ func nonce() string {
 	return strconv.FormatUint(n, 16)
 }
 
+// ValidateLTIRequest is used to validate an LTI request by iterating through known lmss
+// to find the consumer secret for consumer key and using that to match oauth signature
 func ValidateLTIRequest(url string, lmss []interface{}, r *http.Request) bool {
 	ltiConsumerKey := r.FormValue("oauth_consumer_key")
 	var ltiConsumerSecret string

--- a/utils/lti.go
+++ b/utils/lti.go
@@ -21,8 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
-	"github.com/mattermost/mattermost-server/mlog"
-	"github.com/mattermost/mattermost-server/model"
 	"net/http"
 	"net/url"
 	"sort"
@@ -30,6 +28,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/model"
 )
 
 const (
@@ -302,4 +303,3 @@ func ValidateLTIRequest(url string, lmss []interface{}, r *http.Request) bool {
 
 	return true
 }
-

--- a/web/lti.go
+++ b/web/lti.go
@@ -1,20 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package web
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
+	"net/http"
 )
 
 func (w *Web) InitLti() {
-	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLti)).Methods("POST")
+	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLTI)).Methods("POST")
 }
 
-func loginWithLti(c *Context, w http.ResponseWriter, r *http.Request) {
+func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	mlog.Debug("Received an LTI Login request")
 
 	r.ParseForm()
@@ -26,7 +29,7 @@ func loginWithLti(c *Context, w http.ResponseWriter, r *http.Request) {
 	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(c.App.Config().LTISettings.Enable))
 	if !c.App.Config().LTISettings.Enable {
 		mlog.Error("LTI login request when LTI is disabled in config.json")
-		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("loginWithLti", "api.lti.login.error.lti_disabled", nil, "", http.StatusNotImplemented)
 		return
 	}
 

--- a/web/lti.go
+++ b/web/lti.go
@@ -6,33 +6,53 @@ package web
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func (w *Web) InitLti() {
-	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLti)).Methods("POST")
+	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLTI)).Methods("POST")
 }
 
-func loginWithLti(c *Context, w http.ResponseWriter, r *http.Request) {
+func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
+	mlog.Debug("Received an LTI Login request")
+
+	if err := r.ParseForm(); err != nil {
+		mlog.Error("Error occurred while parsing submited form: " + err.Error())
+		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	// printing launch data for debugging purpose
+	mlog.Debug("LTI Launch Data is: ")
+	for k, v := range r.Form {
+		mlog.Debug(fmt.Sprintf("[%s: %s]", k, v[0]))
+	}
+
+	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(c.App.Config().LTISettings.Enable))
 	if !c.App.Config().LTISettings.Enable {
 		mlog.Error("LTI login request when LTI is disabled in config.json")
-		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("loginWithLti", "api.lti.login.error.lti_disabled", nil, "", http.StatusNotImplemented)
 		return
 	}
 
-	if ok := utils.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, c.App.Config().LTISettings.GetKnownLMSs(), r); !ok {
+	mlog.Debug("Validating LTI request")
+	consumerKey := r.FormValue("oauth_consumer_key")
+	lms := c.App.GetLMSToUse(consumerKey)
+
+	if ok := lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r); !ok {
 		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	setLTIDataCookie(c, w, r)
 
+	mlog.Debug("Redirecting to the LTI signup page")
 	http.Redirect(w, r, c.GetSiteURLHeader()+"/signup_lti", http.StatusFound)
 }
 

--- a/web/lti.go
+++ b/web/lti.go
@@ -23,9 +23,10 @@ func (w *Web) InitLti() {
 func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	mlog.Debug("Received an LTI Login request")
 
-	if err := r.ParseForm(); err != nil {
-		mlog.Error("Error occurred while parsing submitted form: " + err.Error())
-		c.Err = model.NewAppError("loginWithLTI", "api.lti.signup.app_error.form.parse_failed", nil, "", http.StatusBadRequest)
+	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(c.App.Config().LTISettings.Enable))
+	if !c.App.Config().LTISettings.Enable {
+		mlog.Error("LTI login request when LTI is disabled in config.json")
+		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -35,59 +36,58 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		mlog.Debug(fmt.Sprintf("[%s: %s]", k, v[0]))
 	}
 
-	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(c.App.Config().LTISettings.Enable))
-	if !c.App.Config().LTISettings.Enable {
-		mlog.Error("LTI login request when LTI is disabled in config.json")
-		c.Err = model.NewAppError("loginWithLTI", "api.lti.signup.app_error.lti_disabled", nil, "", http.StatusNotImplemented)
-		return
+	// to populate r.Form
+	if err := r.ParseForm(); err != nil {
+		mlog.Error("Error occurred while parsing submited form: " + err.Error())
+		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.parse.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	mlog.Debug("Validating LTI request")
 	consumerKey := r.FormValue("oauth_consumer_key")
 	lms := c.App.GetLMSToUse(consumerKey)
 
-	if ok := lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r); !ok {
-		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
+	if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r) {
+		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.validation.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
-	if err := setLTIDataCookie(c, w, r); err != nil {
-		mlog.Error("Error occurred while setting LTI cookies: " + err.Error())
-		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.cookie.set_error", nil, "", http.StatusInternalServerError)
+	encodedRequest, appError := encodeLTIRequest(r.Form)
+	if appError != nil {
+		c.Err = appError
 		return
 	}
+	setLTIDataCookie(c, w, encodedRequest)
 
 	mlog.Debug("Redirecting to the LTI signup page")
 	http.Redirect(w, r, c.GetSiteURLHeader()+"/signup_lti", http.StatusFound)
 }
 
-func encodeLTIRequest(v url.Values) string {
+func encodeLTIRequest(v url.Values) (string, *model.AppError) {
 	if v == nil {
-		return ""
+		mlog.Error("The LTI request form data to be encoded is empty.")
+		return "", model.NewAppError("encodeLTIRequest", "api.lti.login.encoding.app_error", nil, "", http.StatusBadRequest)
 	}
+
 	form := make(map[string]string)
 	for key, value := range v {
 		form[key] = value[0]
 	}
+
 	res, err := json.Marshal(form)
 	if err != nil {
 		mlog.Error("Error in json.Marshal: " + err.Error())
-		return ""
+		return "", model.NewAppError("encodeLTIRequest", "api.lti.login.marshalling.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	return base64.StdEncoding.EncodeToString([]byte(string(res)))
+	return base64.StdEncoding.EncodeToString([]byte(string(res))), nil
 }
 
-func setLTIDataCookie(c *Context, w http.ResponseWriter, r *http.Request) error {
-	if err := r.ParseForm(); err != nil {
-		return err
-	}
-
+func setLTIDataCookie(c *Context, w http.ResponseWriter, encodedRequest string) {
 	maxAge := 600 // 10 minutes
 	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
 	cookie := &http.Cookie{
 		Name:     model.LTI_LAUNCH_DATA_COOKIE,
-		Value:    encodeLTIRequest(r.Form),
+		Value:    encodedRequest,
 		Path:     "/",
 		MaxAge:   maxAge,
 		Expires:  expiresAt,
@@ -96,5 +96,4 @@ func setLTIDataCookie(c *Context, w http.ResponseWriter, r *http.Request) error 
 	}
 
 	http.SetCookie(w, cookie)
-	return nil
 }

--- a/web/lti.go
+++ b/web/lti.go
@@ -42,13 +42,16 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.parse.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	mlog.Debug("Validating LTI request")
-	consumerKey := r.FormValue("oauth_consumer_key")
-	lms := c.App.GetLMSToUse(consumerKey)
+	mlog.Debug("LTI Signature Validation enabled: " +  strconv.FormatBool(c.App.Config().LTISettings.EnableSignatureValidation))
+	if c.App.Config().LTISettings.EnableSignatureValidation {
+		mlog.Debug("Validating LTI request")
+		consumerKey := r.FormValue("oauth_consumer_key")
+		lms := c.App.GetLMSToUse(consumerKey)
 
-	if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r) {
-		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.validation.app_error", nil, "", http.StatusBadRequest)
-		return
+		if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r) {
+			c.Err = model.NewAppError("loginWithLTI", "api.lti.login.validation.app_error", nil, "", http.StatusBadRequest)
+			return
+		}
 	}
 
 	encodedRequest, appError := encodeLTIRequest(r.Form)

--- a/web/lti.go
+++ b/web/lti.go
@@ -4,65 +4,68 @@
 package web
 
 import (
-	"fmt"
-	"strconv"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
-	"net/http"
 )
 
 func (w *Web) InitLti() {
-	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLTI)).Methods("POST")
+	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLti)).Methods("POST")
 }
 
-func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
-	mlog.Debug("Received an LTI Login request")
-
-	r.ParseForm()
-	mlog.Debug("LTI Launch Data is: ")
-	for k, v := range r.Form {
-		mlog.Debug(fmt.Sprintf("[%s: %s]", k, v[0]))
-	}
-
-	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(c.App.Config().LTISettings.Enable))
+func loginWithLti(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !c.App.Config().LTISettings.Enable {
 		mlog.Error("LTI login request when LTI is disabled in config.json")
-		c.Err = model.NewAppError("loginWithLti", "api.lti.login.error.lti_disabled", nil, "", http.StatusNotImplemented)
-		return
-	}
-
-	// Validate request
-	mlog.Debug("Validating LTI request")
-	lmss := c.App.Config().LTISettings.GetKnownLMSs()
-	ltiConsumerKey := r.FormValue("oauth_consumer_key")
-	var ltiConsumerSecret string
-
-	for _, val := range lmss {
-		// TODO: Figure out a better way to find consumer secret for multiple LMSs
-		if lms, ok := val.(model.EdxLMSSettings); ok {
-			if lms.OAuth.ConsumerKey == ltiConsumerKey {
-				ltiConsumerSecret = lms.OAuth.ConsumerSecret
-				break
-			}
-		}
-	}
-
-	if ltiConsumerSecret == "" {
-		mlog.Error("Consumer secret not found for consumer key: " + ltiConsumerKey)
 		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
-	p := utils.NewProvider(ltiConsumerSecret, c.GetSiteURLHeader()+c.Path)
-	p.ConsumerKey = ltiConsumerKey
-	if ok, err := p.IsValid(r); err != nil || ok == false {
-		mlog.Error("Invalid LTI request: " + err.Error())
+	if ok := utils.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, c.App.Config().LTISettings.GetKnownLMSs(), r); !ok {
 		c.Err = model.NewAppError("loginWithLti", "api.lti.login.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
-	mlog.Debug("Redirecting to the LTI signup page")
+	setLTIDataCookie(c, w, r)
+
 	http.Redirect(w, r, c.GetSiteURLHeader()+"/signup_lti", http.StatusFound)
+}
+
+func encodeLTIRequest(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	form := make(map[string]string)
+	for key, value := range v {
+		form[key] = value[0]
+	}
+	res, err := json.Marshal(form)
+	if err != nil {
+		mlog.Error("Error in json.Marshal: " + err.Error())
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(string(res)))
+}
+
+func setLTIDataCookie(c *Context, w http.ResponseWriter, r *http.Request) {
+	r.ParseForm() // to populate r.Form
+	maxAge := 600 // 10 minutes
+	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
+	cookie := &http.Cookie{
+		Name:     model.LTI_LAUNCH_DATA_COOKIE,
+		Value:    encodeLTIRequest(r.Form),
+		Path:     "/",
+		MaxAge:   maxAge,
+		Expires:  expiresAt,
+		Domain:   c.App.GetCookieDomain(),
+		HttpOnly: false,
+	}
+
+	http.SetCookie(w, cookie)
 }

--- a/web/lti.go
+++ b/web/lti.go
@@ -42,16 +42,13 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.parse.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	mlog.Debug("LTI Signature Validation enabled: " +  strconv.FormatBool(c.App.Config().LTISettings.EnableSignatureValidation))
-	if c.App.Config().LTISettings.EnableSignatureValidation {
-		mlog.Debug("Validating LTI request")
-		consumerKey := r.FormValue("oauth_consumer_key")
-		lms := c.App.GetLMSToUse(consumerKey)
+	mlog.Debug("Validate LTI request. LTI Signature Validation enabled: " + strconv.FormatBool(c.App.Config().LTISettings.EnableSignatureValidation))
+	consumerKey := r.FormValue("oauth_consumer_key")
+	lms := c.App.GetLMSToUse(consumerKey)
 
-		if !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r) {
-			c.Err = model.NewAppError("loginWithLTI", "api.lti.login.validation.app_error", nil, "", http.StatusBadRequest)
-			return
-		}
+	if c.App.Config().LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.Path, r) {
+		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.validation.app_error", nil, "", http.StatusBadRequest)
+		return
 	}
 
 	encodedRequest, appError := encodeLTIRequest(r.Form)


### PR DESCRIPTION
#### Summary
- Created API for LTI user signup.
- Make LTI OAuth Signature Validation an optional `config.json` setting: `EnableSignatureValidation`.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
