### PR TITLE
Fix lti logging, typos and new LTISettings config

### DIFF
--- a/config/config-dev.json
+++ b/config/config-dev.json
@@ -329,52 +329,72 @@
     "LTISettings": {
         "Enable": true,
         "EnableSignatureValidation": false,
-        "Lmss": [
-            {
-                "Name": "Emeritus",
-                "Type": "canvas",
-                "Oauth": {
-                    "ConsumerKey": "canvas-emeritus_5863",
-                    "ConsumerSecret": "emeritus secret"
-                },
-                "UserChannels": {
-                    "Type": "emeritus-group",
-                    "AuthorizationToken": "dummy~value",
-                    "ChannelList":
-                    [
-                        {
-                            "CourseType": "plg",
-                            "NameRegEx": "^riff_PLG_"
-                        },
-                        {
-                            "CourseType": "capstone",
-                            "NameRegEx": "^riff_Team_"
-                        }
-                    ]
-                }
-            },
+        "LMSs": [
             {
                 "Name": "Appsembler",
                 "Type": "edx",
-                "Oauth": {
-                    "ConsumerKey": "edx-appsembler-test_5345",
-                    "ConsumerSecret": "secret"
+                "OAuthConsumerKey": "edx-appsembler-test_5345",
+                "OAuthConsumerSecret": "secret",
+                "Teams": {
+                    "course-v1:appsembler-the-red+Riff+101": "riff"
                 },
-                "UserChannels": {
+                "PersonalChannels": {
                     "Type": "custom-properties",
-                    "ChannelList":
-                    [
-                        {
-                            "CourseType": "plg",
+                    "ChannelList": {
+                        "plg": {
                             "NameProperty": "custom_cohort_name",
                             "IdProperty": "custom_cohort_id"
                         },
-                        {
-                            "CourseType": "capstone",
+                        "capstone": {
                             "NameProperty": "custom_team_name",
                             "IdProperty": "custom_team_id"
                         }
-                    ]
+                    }
+                }
+            },
+            {
+                "Name": "BrightScout",
+                "Type": "edx",
+                "OAuthConsumerKey": "brightscout-test_1044",
+                "OAuthConsumerSecret": "secret",
+                "Teams": {
+                    "course-v1:appsembler-the-red+Riff+101": "riff",
+                    "test-context-1": "riff-a",
+                    "test-context-2": "riff-b"
+                },
+                "PersonalChannels": {
+                    "Type": "custom-properties",
+                    "ChannelList": {
+                        "plg": {
+                            "NameProperty": "custom_cohort_name",
+                            "IdProperty": "custom_cohort_id"
+                        },
+                        "capstone": {
+                            "NameProperty": "custom_team_name",
+                            "IdProperty": "custom_team_id"
+                        }
+                    }
+                }
+            },
+            {
+                "Name": "Emeritus",
+                "Type": "canvas",
+                "OAuthConsumerKey": "canvas-emeritus_5863",
+                "OAuthConsumerSecret": "emeritus secret",
+                "Teams": {
+                    "eabb2ed57cf5dec85996803535cbccb4c7f62492": "sloan-1"
+                },
+                "PersonalChannels": {
+                    "Type": "emeritus-groups",
+                    "AuthorizationToken": "dummy~value",
+                    "ChannelList": {
+                        "plg": {
+                            "NameRegEx": "^riff_PLG_"
+                        },
+                        "capstone": {
+                            "NameRegEx": "^riff_Team_"
+                        }
+                    }
                 }
             }
         ]

--- a/model/provider.go
+++ b/model/provider.go
@@ -35,8 +35,8 @@ const (
 	SigHMAC      = "HMAC-SHA1"
 )
 
-// Provider is an app, that can consume LTI messages,
-// also a provider could be used, to construct messages and sign them
+// Provider is an app that can consume LTI messages,
+// also a provider could be used to construct messages and sign them
 //
 //  p := lti.NewProvider("secret", "http://url.com")
 //  p.Add("param_name", "vale").
@@ -44,13 +44,13 @@ const (
 //
 //  sig, err := p.Sign()
 //
-// will sign, the request, and add the needed fields to the
+// will sign the request, and add the needed fields to the
 // Provider.values > Can access it throught p.Params()
 // It also can be used to Verify and handle, incoming LTI requests.
 //
-//  p.IsValid(requesto)
+//  p.IsValid(request)
 //
-// A Provider also holds a internal params url.Values, that can
+// A Provider also holds an internal params url.Values, that can
 // be accessed via Get, or Add.
 type Provider struct {
 	Secret      string
@@ -76,7 +76,7 @@ func NewProvider(secret, urlSrv string) *Provider {
 	}
 }
 
-// HasRole checks if a LTI request, has a provided role
+// HasRole checks if an LTI request has a provided role
 func (p *Provider) HasRole(role string) bool {
 	ro := strings.Split(p.Get("roles"), ",")
 	roles := strings.Join(ro, " ") + " "
@@ -102,7 +102,7 @@ func (p *Provider) SetParams(v url.Values) *Provider {
 	return p
 }
 
-// Add a new param to a LTI request
+// Add a new param to an LTI request
 func (p *Provider) Add(k, v string) *Provider {
 	if p.values == nil {
 		p.values = url.Values{}
@@ -119,8 +119,8 @@ func (p *Provider) Empty(key string) bool {
 	return p.values.Get(key) == ""
 }
 
-// Sign a request, adding, required fields,
-// A request, can be drilled on a template, iterating, over p.Prams()
+// Sign a request, adding required fields,
+// A request, can be drilled on a template, iterating, over p.Params()
 func (p *Provider) Sign() (string, error) {
 	if p.Empty("oauth_version") {
 		p.Add("oauth_version", oAuthVersion)

--- a/web/lti.go
+++ b/web/lti.go
@@ -6,7 +6,6 @@ package web
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -30,17 +29,22 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// printing launch data for debugging purpose
-	mlog.Debug("LTI Launch Data is: ")
-	for k, v := range r.Form {
-		mlog.Debug(fmt.Sprintf("[%s: %s]", k, v[0]))
-	}
-
 	// to populate r.Form
 	if err := r.ParseForm(); err != nil {
-		mlog.Error("Error occurred while parsing submited form: " + err.Error())
+		mlog.Error("Error occurred while parsing submitted form: " + err.Error())
 		c.Err = model.NewAppError("loginWithLTI", "api.lti.login.parse.app_error", nil, "", http.StatusBadRequest)
+		return
 	}
+
+	// printing launch data for debugging purposes
+	body := make(map[string]string)
+	for k, v := range r.Form {
+		body[k] = v[0]
+	}
+	
+	url := c.GetSiteURLHeader()+c.Path
+	mlog.Debug("LTI Launch Data", mlog.String("URL", url),
+								  mlog.Any("Body", body))
 
 	mlog.Debug("Validate LTI request. LTI Signature Validation enabled: " + strconv.FormatBool(c.App.Config().LTISettings.EnableSignatureValidation))
 	consumerKey := r.FormValue("oauth_consumer_key")


### PR DESCRIPTION
#### Summary
- The form properties can't be iterated to be logged until after the form is parsed
- It will be easier to deal w/ a single log entry for the LTI launch data
- When a form parse error occurs it was logged but the code was missing a return afterwards
- there were minor typos in provider.go that were fixed
- Updated the LTISettings configuration setting in config-dev.json to match the latest organization
  and put the Emeritus LMS last (as it is an example of configuration for future possible functionality)

#### Checklist

