### PR TITLE
Lti auth: Don't redirect to LTI signup page if one or more required user fields is missing (merge to develop)

### DIFF
--- a/web/lti.go
+++ b/web/lti.go
@@ -56,6 +56,13 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		// Case: MM or LTI User not found
 		mlog.Debug("MM or LTI User not found")
 		c.Logout(w, r)
+
+		// Don't redirect to signup page if BuildUser is going to fail
+		if _, err := lms.BuildUser(launchData, ""); err != nil {
+			c.Err = err
+			return
+		}
+
 		if err := setLTIDataCookie(c, w, launchData); err != nil {
 			c.Err = err
 			return


### PR DESCRIPTION
#### Summary
Fix issue - If launch data is missing any user fields, redirect to error page rather than to the create user page.
