### PR TITLE
fix LTI private team channel creation

### DIFF
--- a/app/lti.go
+++ b/app/lti.go
@@ -123,7 +123,7 @@ func (a *App) createChannelsIfRequired(teamId string, channels map[string]string
 
 			channel, err = a.CreateChannel(channel, false)
 			if err != nil {
-				mlog.Error("Failed to create channel for LMS onboarding: " + err.Error())
+				mlog.Error("Failed to create channel for LMS onboarding: "+err.Error(), mlog.Any("Channel", channel))
 				continue
 			}
 		}

--- a/model/lti.go
+++ b/model/lti.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/mattermost/mattermost-server/mlog"
 )
@@ -97,8 +98,12 @@ func transformLTIUsername(ltiUsername string) string {
 }
 
 func GetLMSChannelSlug(personalChannelName, channelId string) string {
-	channelSlug := fmt.Sprintf("%s-%s", personalChannelName, channelId)
-	return truncateLMSChannelSlug(channelSlug)
+	channelSlugRaw := fmt.Sprintf("%s-%s", personalChannelName, channelId)
+	// This trim is a patch because creating the channel fails if the slug ends w/ a '-'
+	// What we should do is remove all non alphanumeric characters from the channelId and lowercase it
+	// and then concatenate and truncate.
+	channelSlug := strings.Trim(truncateLMSChannelSlug(channelSlugRaw), "-")
+	return channelSlug
 }
 
 func truncateLMSChannelSlug(channelSlug string) string {


### PR DESCRIPTION
#### Summary
A channel slug must end w/ an alphanumeric. The LTI code which creates the channel slug
did not test and fix this condition.

This is a temporary "hotfix" which does should allow the channels which failed to get
created to now be created, WITHOUT changing the slug names for the channels which were
being successfully created.

A better long term fix is to remove all non-alphanumeric characters from the channel ID
string, lowercase it, and then append and truncate as required.

#### Ticket Link
[Trello #299](https://trello.com/c/sGO8Dbz5) Some LTI team channels fail to be created

