### PR TITLE
Implement UserAnalytics

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -22,6 +22,7 @@ type Routes struct {
 	User           *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}'
 	UserByUsername *mux.Router // 'api/v4/users/username/{username:[A-Za-z0-9_-\.]+}'
 	UserByEmail    *mux.Router // 'api/v4/users/email/{email}'
+	UserAnalytics  *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}/teams/{team_id:[A-Za-z0-9_-]+}/useranalytics'
 
 	Teams              *mux.Router // 'api/v4/teams'
 	TeamsForUser       *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}/teams'
@@ -131,6 +132,7 @@ func Init(a *app.App, root *mux.Router) *API {
 	api.BaseRoutes.User = api.BaseRoutes.ApiRoot.PathPrefix("/users/{user_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.UserByUsername = api.BaseRoutes.Users.PathPrefix("/username/{username:[A-Za-z0-9\\_\\-\\.]+}").Subrouter()
 	api.BaseRoutes.UserByEmail = api.BaseRoutes.Users.PathPrefix("/email/{email}").Subrouter()
+	api.BaseRoutes.UserAnalytics = api.BaseRoutes.User.PathPrefix("/teams/{team_id:[A-Za-z0-9]+}/useranalytics").Subrouter()
 
 	api.BaseRoutes.Teams = api.BaseRoutes.ApiRoot.PathPrefix("/teams").Subrouter()
 	api.BaseRoutes.TeamsForUser = api.BaseRoutes.User.PathPrefix("/teams").Subrouter()

--- a/app/user.go
+++ b/app/user.go
@@ -1634,3 +1634,120 @@ func (a *App) RecordUserTermsOfServiceAction(userId, termsOfServiceId string, ac
 
 	return nil
 }
+
+func (a *App) GetUserAnalytics(userId string, teamId string, name string) (*model.UserAnalytics, *model.AppError) {
+	// Is a placeholder for the result of all assertion tests in this function
+	var assertionSuccess bool
+
+	// Initialize returnData struct as UserInteractions type
+	// returnData will contain all datasets related to user analytics
+	// Find the definition of the UserAnalytics type in model/user.go
+	returnData := new(model.UserAnalytics)
+
+	// Always return the target user's id as a data set
+	returnData.TargetUser = userId
+
+	// Instantiate learningGroupTypes and error structs
+	// They will be used to store the results of a.GetLearningGroupTypes(teamId) below
+	var learningGroupTypes []*model.LearningGroupType
+	var err *model.AppError
+
+	// Get learning group types (ex. 'plg' or 'capstone')
+	// Learning group types are used to identify private channels that
+	// were automatically generated for a learning group
+	//     Ex. If a private channel's name is 'plg-30', and the following function
+	//         returns 'plg' as a learning group prefix, then we can reasonably assert
+	//         that channel 'plg-30', was an automatically generated private channel
+	//         for a learning group of type 'plg'
+	if learningGroupTypes, err = a.GetLearningGroupTypes(teamId); err != nil {
+		// Return and exit from GetUserAnalytics with error
+		return nil, err
+	}
+
+	// Add learningGroupTypes to return data (always return learning group types)
+	// Assert as type 'array of pointers to LearningGroupType structs'
+	if returnData.LearningGroupTypes, assertionSuccess = interface{}(learningGroupTypes).([]*model.LearningGroupType); !assertionSuccess {
+		// Return and exit from GetUserAnalytics with error
+		return nil, model.NewAppError("GetUserAnalytics", "api.user.get_user_analytics.learning_group_prefix_assertion_error", nil, "", http.StatusBadRequest)
+	}
+
+	// Manually check what data set is being requested
+	if name == "UserInteractions" {
+		if userInteractions := <-a.Srv.Store.User().GetUserInteractions(userId, teamId, learningGroupTypes); userInteractions.Err != nil {
+			// Return and exit from GetUserAnalytics with error
+			return nil, userInteractions.Err
+		} else {
+			// Add UserInteractions data to the returnData object
+			// Assert as type 'array of pointers to UserInteraction structs'
+			if returnData.UserInteractions, assertionSuccess = userInteractions.Data.([]*model.UserInteraction); !assertionSuccess {
+				// Return and exit from GetUserAnalytics with error
+				return nil, model.NewAppError("GetUserAnalytics", "api.user.get_user_analytics.user_interaction_assertion_error", nil, "", http.StatusBadRequest)
+			}
+		}
+	}
+
+	// Always return the user's learning groups
+	if userLearningGroups := <-a.Srv.Store.User().GetUserLearningGroups(userId, teamId, learningGroupTypes); userLearningGroups.Err != nil {
+		// Return and exit from GetUserAnalytics with error
+		return nil, userLearningGroups.Err
+	} else {
+		// Add LearningGroups data to the returnData object
+		// Assert as type 'array of pointers to LearningGroup structs'
+		if returnData.UserLearningGroups, assertionSuccess = userLearningGroups.Data.([]*model.LearningGroup); !assertionSuccess {
+			// Return and exit from GetUserAnalytics with error
+			return nil, model.NewAppError("GetUserAnalytics", "api.user.get_user_analytics.learning_group_assertion_error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	// Return returnData, which is of type UserAnalytics, and nil as error
+	return returnData, nil
+}
+
+// Get the learning group types for the specified team
+//
+// Learning group types only exist if the specified team is associated with an
+// LMS course used for LTI sign-in which has personal channels defined.
+//
+// Each personal channel of an LMS defines a type of learning group. The names
+// of these personal channels are unique and are used as a prefix when determining
+// the private learning group channel of that type for a user signing in from an LMS.
+//
+// Currently the only property of a LearngGroupType is that prefix string. And the
+// value of that prefix uniquely identifies that LearningGroupType.
+//
+//     ex. if we determine that a learning group type has a prefix of 'capstone',
+//         then we can reasonably assert that any private channel whose name is
+//         prefixed with 'capstone-', is a learning group channel of that type and the
+//         users that are a member of that channel belong to that
+//         learning group.
+//
+//         This is used by GetUserAnalytics to analyze interactions between the
+//         members of that group.
+func (a *App) GetLearningGroupTypes(teamId string) ([]*model.LearningGroupType, *model.AppError) {
+	// Get mattermost team data
+	// Really just need Team.Name, which is equal to the team slug
+	var currentTeamSlug string
+	if result := <-a.Srv.Store.Team().Get(teamId); result.Err != nil {
+		return nil, result.Err
+	} else {
+		currentTeam := result.Data.(*model.Team)
+		currentTeamSlug = currentTeam.Name
+	}
+
+	var learningGroupTypes []*model.LearningGroupType
+
+	// Find the LMS that has a contextId (course) mapped to the current team
+	for _, lms := range a.Config().LTISettings.GetKnownLMSs() {
+		if lms.IsLMSForTeam(currentTeamSlug) {
+			personalChannelNames := lms.GetPersonalChannelNames()
+
+			// Create a LearningGroupType for each personal channel
+			learningGroupTypes = make([]*model.LearningGroupType, len(personalChannelNames))
+			for i, channelName := range personalChannelNames {
+				learningGroupTypes[i] = &model.LearningGroupType{Prefix: channelName}
+			}
+		}
+	}
+
+	return learningGroupTypes, nil
+}

--- a/model/edx.go
+++ b/model/edx.go
@@ -67,6 +67,27 @@ func (e *EdxLMS) GetOAuthConsumerSecret() string {
 	return e.OAuthConsumerSecret
 }
 
+// If this LMS has an LTI contextId (course ID) associated with the given team return true
+func (e *EdxLMS) IsLMSForTeam(teamSlug string) bool {
+	for _, lmsTeamSlug := range e.Teams {
+		if lmsTeamSlug == teamSlug {
+			return true
+		}
+	}
+	return false
+}
+
+// Get the names of the personal channels (order of the names will be random)
+func (e *EdxLMS) GetPersonalChannelNames() []string {
+	// At the current time there are only 2 personal channels, so we might as well set the
+	// capacity to that.
+	channelNames := make([]string, 0, 2)
+	for personalChannelName := range e.PersonalChannels.ChannelList {
+		channelNames = append(channelNames, personalChannelName)
+	}
+	return channelNames
+}
+
 func (e *EdxLMS) GetUserId(launchData map[string]string) string {
 	return launchData[launchDataLTIUserIdKey]
 }

--- a/model/lti.go
+++ b/model/lti.go
@@ -35,6 +35,8 @@ type LMS interface {
 	GetType() string
 	GetOAuthConsumerKey() string
 	GetOAuthConsumerSecret() string
+	GetPersonalChannelNames() []string
+	IsLMSForTeam(teamSlug string) bool
 	GetUserId(launchData map[string]string) string
 	ValidateLTIRequest(url string, request *http.Request) bool
 	BuildUser(launchData map[string]string, password string) (*User, *AppError)

--- a/model/user.go
+++ b/model/user.go
@@ -47,6 +47,77 @@ const (
 	USER_PASSWORD_MAX_LENGTH  = 72
 )
 
+// This is a struct for a user interaction
+// A user interaction will represent one row in the results of the
+// GetUserInteractions query in store/sqlstore/user_store.go
+type UserInteraction struct {
+	// The type of interaction
+	// enum('Reaction', 'Mention', 'Reply', 'DirectMessage')
+	InteractionType string `json:"interaction_type"`
+
+	// The username of the user that this interaction took place with
+	Username string `json:"username"`
+
+	// Denotes whether or not the current user was the recipient of this interaction
+	IsRecipient bool `json:"is_recipient"`
+
+	// The context in which this interaction occurred (either 'Course' or the learning group type's prefix (ex. 'plg'))
+	Context string `json:"context"`
+
+	// The type of channel that this interaction took place in
+	// enum('P', 'O', 'D', 'G')
+	//     P = private channel
+	//     O = public channel
+	//     D = direct message (1 on 1)
+	//     G = group direct message
+	ChannelType string `json:"channel_type"`
+
+	// The slug name of the channel that this interaction took place in (Channels.Name)
+	ChannelName string `json:"channel_name"`
+}
+
+// This is a struct for a learning group type
+// Each learning group type is derived from personal channel names found in the config
+type LearningGroupType struct {
+	// ex. 'capstone'
+	Prefix string `json:"prefix"`
+}
+
+// This is a struct for all user analytics data sets
+// This is the struct that gets returned to mattermost-redux in the users/{userId}/teams/{teamId}/useranalytics request
+// **Note: Using pointers as property types allows for null values
+type UserAnalytics struct {
+	TargetUser         string               `json:"TargetUser"`
+	UserInteractions   []*UserInteraction   `json:"UserInteractions"`
+	UserLearningGroups []*LearningGroup     `json:"UserLearningGroups"`
+	LearningGroupTypes []*LearningGroupType `json:"LearningGroupTypes"`
+	// Add more datasets here
+}
+
+// This is a struct for a learning group (ex. capstone)
+// **Note: Using pointers as property types allows for null values
+type LearningGroup struct {
+	// The name of the learning group (the channel name minus the learning group type's prefix)
+	//     ex. plg-30 => 30
+	LearningGroupName string `json:"learning_group_name"`
+
+	// The prefix for this learning group type (personal channel name from the config)
+	//     ex. plg
+	LearningGroupPrefix string `json:"learning_group_prefix"`
+
+	// The id of the private channel for this learning group
+	ChannelId string `json:"channel_id"`
+
+	// The slug name of the private channel for this learning group (Channels.Name)
+	ChannelName string `json:"channel_name"`
+
+	// A comma delimited list of the usernames of the members of this learning group (channel)
+	Members *string `json:"members"`
+
+	// Denotes whether or not the current user has left this learning group
+	HasLeftGroup bool `json:"has_left_group"`
+}
+
 type User struct {
 	Id                       string    `json:"id"`
 	CreateAt                 int64     `json:"create_at,omitempty"`
@@ -343,6 +414,12 @@ func (u *UserPatch) ToJson() string {
 }
 
 func (u *UserAuth) ToJson() string {
+	b, _ := json.Marshal(u)
+	return string(b)
+}
+
+// Used to convert a UserAnalytics struct to json
+func (u *UserAnalytics) ToJson() string {
 	b, _ := json.Marshal(u)
 	return string(b)
 }

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -428,15 +428,15 @@ func (us SqlUserStore) GetProfilesInChannel(channelId string, offset int, limit 
 		var users []*model.User
 
 		query := `
-				SELECT 
-					Users.* 
-				FROM 
-					Users, ChannelMembers 
-				WHERE 
-					ChannelMembers.ChannelId = :ChannelId 
-					AND Users.Id = ChannelMembers.UserId 
-				ORDER BY 
-					Users.Username ASC 
+				SELECT
+					Users.*
+				FROM
+					Users, ChannelMembers
+				WHERE
+					ChannelMembers.ChannelId = :ChannelId
+					AND Users.Id = ChannelMembers.UserId
+				ORDER BY
+					Users.Username ASC
 				LIMIT :Limit OFFSET :Offset
 		`
 
@@ -458,21 +458,21 @@ func (us SqlUserStore) GetProfilesInChannelByStatus(channelId string, offset int
 		var users []*model.User
 
 		query := `
-			SELECT 
+			SELECT
 				Users.*
 			FROM Users
 				INNER JOIN ChannelMembers ON Users.Id = ChannelMembers.UserId
 				LEFT JOIN Status  ON Users.Id = Status.UserId
 			WHERE
 				ChannelMembers.ChannelId = :ChannelId
-			ORDER BY 
+			ORDER BY
 				CASE Status
 					WHEN 'online' THEN 1
 					WHEN 'away' THEN 2
 					WHEN 'dnd' THEN 3
 					ELSE 4
 				END,
-				Users.Username ASC 
+				Users.Username ASC
 			LIMIT :Limit OFFSET :Offset
 		`
 
@@ -1359,5 +1359,472 @@ func (us SqlUserStore) InferSystemInstallDate() store.StoreChannel {
 			return
 		}
 		result.Data = createAt
+	})
+}
+
+// This function will run an sql query and return all relevant user interactions for the current user in the current mattermost team
+// Each result row will be of type UserInteraction (defined in model/user.go)
+// TODO: Break the query in this function into smaller, more maintainable queries perhaps using a query builder
+func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learningGroupTypes []*model.LearningGroupType) store.StoreChannel {
+
+	// For every learning group type for this team, use this case statement
+	// to record the interaction in this learning group type's context (ex. plg)
+	prefixQuery := ""
+
+	for _, learningGroupType := range learningGroupTypes {
+		prefixQuery += `
+			WHEN Channels.Type = 'P'
+			AND LEFT(Channels.Name,` + strconv.Itoa(len(learningGroupType.Prefix)+1) + `) = '` + learningGroupType.Prefix + `-'
+			THEN LEFT(Channels.Name,` + strconv.Itoa(len(learningGroupType.Prefix)) + `)
+		`
+	}
+
+	// If there are no learning group types, create negative test case to default as 'course'
+	// No types means: this mattermost team is not associated with a course
+	if len(prefixQuery) == 0 {
+		prefixQuery = " WHEN 1 != 1 THEN '' "
+	}
+
+	return store.Do(func(result *store.StoreResult) {
+		query :=
+			`
+			SELECT * FROM (
+
+				(-- Reactions - Not Recipient
+				SELECT 'Reaction' AS 'InteractionType',
+				Users.Username,
+				0 AS 'IsRecipient',
+				CASE
+				    ` + prefixQuery + `
+				    ELSE 'course'
+
+				END AS 'Context',
+				Channels.Type AS 'ChannelType',
+				Channels.Name AS 'ChannelName'
+
+				    FROM Reactions
+
+				    JOIN Users
+				    ON Users.Id = (SELECT UserId FROM Posts WHERE Id = Reactions.PostId)
+
+				    JOIN Posts
+				    ON Posts.Id = Reactions.PostId
+
+				    JOIN Channels
+				    ON Channels.Id = Posts.ChannelId
+						AND (Channels.TeamID = :teamId OR Channels.Type IN ('D', 'G'))
+
+				WHERE Reactions.UserId = :userId
+				AND Posts.UserId != :userId
+				)
+
+				UNION ALL
+
+				(-- Reactions - Is Recipient
+				SELECT 'Reaction' AS 'InteractionType',
+				Users.Username,
+				1 AS 'IsRecipient',
+				CASE
+						` + prefixQuery + `
+						ELSE 'course'
+
+				END AS 'Context',
+				Channels.Type AS 'ChannelType',
+				Channels.Name AS 'ChannelName'
+
+				    FROM Reactions
+
+				    JOIN Posts
+				    ON Reactions.PostId = Posts.Id
+
+				    JOIN Users
+				    ON Users.Id = Reactions.UserId
+
+				    JOIN Channels
+				    ON Channels.Id = Posts.ChannelId
+						AND (Channels.TeamID = :teamId OR Channels.Type IN ('D', 'G'))
+
+				WHERE Posts.UserId = :userId
+				AND Reactions.UserId != :userId
+				)
+
+				UNION ALL
+
+				(-- Mentions -Recipient AND Not Recipient
+				SELECT 'Mention' AS 'InteractionType',
+				CASE
+				    WHEN
+				        Mentioner.Id = :userId
+				        THEN Mentionee.Username
+				    WHEN
+				        Mentionee.Id = :userId
+				        THEN Mentioner.Username
+				END AS 'Username',
+				CASE
+				    WHEN
+				        Mentioner.Id = :userId
+				        THEN 0
+				    WHEN
+				        Mentionee.Id = :userId
+				        THEN 1
+				END AS 'IsRecipient',
+				CASE
+						` + prefixQuery + `
+						ELSE 'course'
+
+				END AS 'Context',
+				Channels.Type AS 'ChannelType',
+				Channels.Name AS 'ChannelName'
+
+				    FROM Users Mentionee
+
+				    JOIN Posts
+				    ON Message LIKE (CONCAT('%@',Mentionee.Username,'%'))
+
+				    JOIN Users Mentioner
+				    ON Mentioner.Id = Posts.UserId
+
+				    JOIN Channels
+				    ON Channels.Id = Posts.ChannelId
+						AND (Channels.TeamID = :teamId OR Channels.Type IN ('D', 'G'))
+
+				WHERE ((Mentioner.Id = :userId AND Mentionee.Id != :userId)
+				OR (Mentionee.Id = :userId AND Mentioner.Id != :userId))
+				)
+
+				UNION ALL
+
+				(-- Replies -Recipient AND Not Recipient
+				SELECT 'Reply' AS 'InteractionType',
+				CASE
+				    WHEN
+				        Reply.UserId = :userId
+				        THEN Replyee.Username
+				    WHEN
+				        OriginalPost.UserId = :userId
+				        THEN Replier.Username
+				END AS 'Username',
+				CASE
+				    WHEN
+				        Reply.UserId = :userId
+				        THEN 0
+				    WHEN
+				        OriginalPost.UserId = :userId
+				        THEN 1
+				END AS 'IsRecipient',
+				CASE
+						` + prefixQuery + `
+						ELSE 'course'
+
+				END AS 'Context',
+				Channels.Type AS 'ChannelType',
+				Channels.Name AS 'ChannelName'
+
+				  FROM Posts Reply
+
+				    JOIN Posts OriginalPost
+				    ON OriginalPost.Id = Reply.ParentId
+
+				    JOIN Channels
+				    ON Channels.Id = Reply.ChannelId
+						AND Channels.TeamID = :teamId
+
+				    JOIN Users Replier
+				    ON Replier.Id = Reply.UserId
+
+				    JOIN Users Replyee
+				    ON Replyee.Id = OriginalPost.UserId
+
+				WHERE Reply.ParentId != ''
+				AND Channels.Type NOT IN ('D', 'G')
+				AND Reply.OriginalId = ''
+				AND OriginalPost.OriginalId = ''
+				AND ((Reply.UserId = :userId AND OriginalPost.UserId != :userId) OR
+				(OriginalPost.UserId = :userId AND Reply.UserId != :userId))
+				)
+
+				UNION ALL
+
+				(-- Direct Messages -Recipient AND Not Recipient
+				SELECT 'DirectMessage' AS 'InteractionType',
+				CASE
+				    WHEN
+				        PostAuthor.Id = :userId
+				        THEN PostRecipient.Username
+				    ELSE PostAuthor.Username
+				END AS 'Username',
+				CASE
+				    WHEN
+				        PostAuthor.Id = :userId
+				        THEN 0
+				    ELSE 1
+				END AS 'IsRecipient',
+				'course' AS 'Context',
+				Channels.Type AS 'ChannelType',
+				Channels.Name AS 'ChannelName'
+
+				    FROM Posts
+
+				    JOIN Users PostAuthor -- Sender of the direct message
+				    ON PostAuthor.Id = Posts.UserId
+
+				    JOIN Users PostRecipient
+				    ON PostRecipient.Id IN (SELECT UserId
+				                                FROM ChannelMembers CH
+				                            WHERE CH.ChannelId = Posts.ChannelId
+				                            AND UserId != :userId)
+				    JOIN Channels
+				    ON Channels.Id = Posts.ChannelId
+
+				    JOIN ChannelMembers
+				    ON ChannelMembers.ChannelId = Channels.Id
+				    AND ChannelMembers.UserId = :userId
+
+				WHERE Channels.Type = 'D'
+				AND Posts.OriginalId = ''
+				)
+
+				UNION ALL ( -- all posts and replies in group messaging channels (Channels.Type = 'G')
+				SELECT
+				CASE
+				    WHEN
+				        TargetInteraction.InteractionType = 'DirectMessage' -- a catch all, all posts in group messages that are not replies, will be recorded as direct messages
+				        OR
+				        (TargetInteraction.InteractionType = 'Reply' -- reply, NOT written by current user, to a post that the current user DID NOT write, record a direct message to current user
+				        AND TargetInteraction.UserId != :userId
+				        AND Parent_Post_Author_Id != :userId)
+				        OR
+				        (TargetInteraction.InteractionType = 'Reply' -- reply, written by current user, record a direct message to all users in channel besides parent post's author
+				        AND TargetInteraction.UserId = :userId
+				        AND Parent_Post_Author_Id != ChannelMembers.UserId)
+
+				        THEN 'DirectMessage'
+				    WHEN
+				        (TargetInteraction.InteractionType = 'Reply'-- reply, NOT written by current user, and this user is the author of the parent post (mark as reply to that user)
+				        AND TargetInteraction.UserId != :userId
+				        AND Parent_Post_Author_Id = :userId)
+				        OR
+				        (TargetInteraction.InteractionType = 'Reply' -- reply, written by current user, record as reply to author of parent post (if author of parent post isn't the current user)
+				        AND TargetInteraction.UserId = :userId
+				        AND Parent_Post_Author_Id != :userId
+				        AND Parent_Post_Author_Id = ChannelMembers.UserId)
+
+				        THEN 'Reply'
+				END AS 'InteractionType',
+				CASE
+				    WHEN
+				        TargetInteraction.UserId != :userId
+				        THEN TargetInteraction.Username
+				        ELSE ChannelMembersUsers.Username
+				END AS 'Username',
+				CASE
+				    WHEN
+				        TargetInteraction.UserId != :userId
+				        THEN 1
+				        ELSE 0
+				END AS 'IsRecipient',
+				'course' AS 'Context',
+				ChannelType,
+				ChannelName
+
+				    FROM ChannelMembers
+
+				    JOIN Users ChannelMembersUsers
+				    ON ChannelMembersUsers.Id = ChannelMembers.UserId
+
+				    JOIN (
+					        SELECT
+					        CASE
+					            WHEN
+					                Posts.ParentId = ''
+					                THEN 'DirectMessage'
+					            ELSE 'Reply'
+					        END AS 'InteractionType',
+					        ChannelMembersUsers.Id AS 'UserId',
+					        ChannelMembersUsers.Username AS 'Username',
+					        Channels.Id AS 'ChannelId',
+					        ParentPostAuthor.Id AS 'Parent_Post_Author_Id',
+					        Posts.Id AS 'PostId',
+					        Channels.Type AS 'ChannelType',
+					        Channels.Name AS 'ChannelName'
+
+					            FROM Posts
+
+					            JOIN Users ChannelMembersUsers
+					            ON ChannelMembersUsers.Id = Posts.UserId
+
+					            LEFT JOIN Users ParentPostAuthor -- if the post is a reply, then get the parent post's author's id
+					            ON ParentPostAuthor.Id = (SELECT UserId FROM Posts ParentPost WHERE ParentPost.Id = Posts.ParentId)
+
+					            JOIN Channels
+					            ON Channels.Id = Posts.ChannelId
+
+											JOIN ChannelMembers
+					            ON ChannelMembers.ChannelId = Channels.Id
+					            AND ChannelMembers.UserId = :userId
+
+					        WHERE Channels.Type = 'G'
+					        AND Posts.OriginalId = ''
+				    		) TargetInteraction
+				    ON TargetInteraction.ChannelId = ChannelMembers.ChannelId
+
+				WHERE (TargetInteraction.InteractionType = 'DirectMessage' -- direct message from someone other than current user in group channel
+				        AND TargetInteraction.UserId != :userId
+				        AND ChannelMembers.UserId = :userId)
+
+				OR  (TargetInteraction.InteractionType = 'DirectMessage' -- direct message from current user in group channel
+				    AND TargetInteraction.UserId = :userId
+				    AND ChannelMembers.UserId != :userId)
+
+				OR (TargetInteraction.InteractionType = 'Reply' -- reply, not written by current user, to a post that the current user IS an author of, in a group channel
+				        AND TargetInteraction.UserId != :userId
+				        AND Parent_Post_Author_Id = :userId
+				        AND ChannelMembersUsers.Id = :userId) -- just want one user returned from channel members (the current user) (will record as a reply)
+
+				OR (TargetInteraction.InteractionType = 'Reply' -- reply, not written by current user, to a post that the current user IS NOT an author of, in a group channel
+				        AND TargetInteraction.UserId != :userId
+				        AND Parent_Post_Author_Id != :userId
+				        AND ChannelMembersUsers.Id = :userId) -- just want one user returned from channel members (the current user) (will record as a DM)
+
+				OR (TargetInteraction.InteractionType = 'Reply' -- reply, written by current user, to a post that the current user IS NOT an author of, in a group channel
+				        AND TargetInteraction.UserId = :userId
+				        AND Parent_Post_Author_Id != :userId
+				        AND ChannelMembersUsers.Id != :userId)
+
+				OR (TargetInteraction.InteractionType = 'Reply' -- reply, written by current user, to a post that the current user IS an author of, in a group channel
+				        AND TargetInteraction.UserId = :userId
+				        AND Parent_Post_Author_Id = :userId
+				        AND ChannelMembersUsers.Id != :userId)
+				)
+			) AS UserInteractions
+
+			WHERE Username IN (SELECT Username -- all interactions must take place with users on your team
+			                          FROM Users
+
+			                            JOIN TeamMembers
+			                            ON TeamMembers.TeamID = :teamId
+			                            AND TeamMembers.UserId = Users.Id
+			                        )
+			`
+		var userInteractions []*model.UserInteraction
+
+		if _, err := us.GetReplica().Select(&userInteractions, query, map[string]interface{}{"userId": userId, "teamId": teamId}); err != nil {
+			result.Err = model.NewAppError("SqlUserStore.GetUserInteractions", "store.sql_post.ge_user_interactions.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		result.Data = userInteractions
+	})
+}
+
+// This function will run an sql query and, using the learningGroupTypes as a reference, return all learning groups that this user is a member of
+//     ex. if 'capstone' is a learning group type, and this user is a member of a private channel named 'capstone-30', then that channel is considered a learning group
+// Each result row will be of type LearningGroup (defined in model/user.go)
+func (us *SqlUserStore) GetUserLearningGroups(userId string, teamId string, learningGroupTypes []*model.LearningGroupType) store.StoreChannel {
+	// For every learning group type for this team, use this case statement
+	// to record a name for this channel(team), minus the prefix (ex. plg-30 => 30)
+	prefixReplaceQuery := ""
+
+	for _, learningGroupType := range learningGroupTypes {
+		prefixReplaceQuery += `
+		WHEN LEFT(Channels.Name,` + strconv.Itoa(len(learningGroupType.Prefix)+1) + `) = '` + learningGroupType.Prefix + `-'
+		THEN REPLACE(Channels.Name,'` + learningGroupType.Prefix + `-','')
+		`
+	}
+
+	// If there are no learning group types, then '' as team name,
+	// since this should be a 1 to 1 relationship
+	if len(prefixReplaceQuery) == 0 {
+		prefixReplaceQuery = " WHEN 1 = 1 THEN '' "
+	}
+
+	// For every learning group type for this team, use this case statement
+	// to get a team type for this channel(team) (ex. plg-30 => plg)
+	prefixQuery := ""
+
+	for _, learningGroupType := range learningGroupTypes {
+		prefixQuery += `
+		WHEN LEFT(Channels.Name,` + strconv.Itoa(len(learningGroupType.Prefix)+1) + `) = '` + learningGroupType.Prefix + `-'
+		THEN '` + learningGroupType.Prefix + `'
+		`
+	}
+
+	// If there are no learning group types, then '' as team type,
+	// since this should be a 1 to 1 relationship
+	if len(prefixQuery) == 0 {
+		prefixQuery = " WHEN 1 = 1 THEN '' "
+	}
+
+	// For every learning group type for this team, use this case statement
+	// to find all channels with a name that starts with the prefix
+	prefixFilterQuery := ""
+
+	for _, learningGroupType := range learningGroupTypes {
+		if len(prefixFilterQuery) > 0 {
+			prefixFilterQuery += " OR "
+		}
+		prefixFilterQuery += `
+		LEFT(Channels.Name,` + strconv.Itoa(len(learningGroupType.Prefix)+1) + `) = '` + learningGroupType.Prefix + `-'
+		`
+	}
+
+	// If there are no learning group types, then use 1 != 1 to return no results,
+	// since no types means no learning group channels
+	if len(prefixFilterQuery) == 0 {
+		prefixFilterQuery = " 1 != 1 "
+	}
+
+	return store.Do(func(result *store.StoreResult) {
+		query :=
+			`
+				SELECT
+				CASE
+				` + prefixReplaceQuery + `
+				END AS 'LearningGroupName',
+				CASE
+				` + prefixQuery + `
+				END AS 'LearningGroupPrefix',
+				Channels.Id AS 'ChannelId',
+				Channels.Name AS 'ChannelName',
+				(
+				SELECT GROUP_CONCAT(Users.Username)
+				    FROM Users
+				WHERE Users.Id IN (SELECT UserId
+                               FROM ChannelMembers CM
+                           WHERE CM.ChannelId = Channels.Id
+                           AND UserId != :userId
+                           )
+				) AS 'Members',
+
+				(
+					SELECT CASE
+							WHEN ChannelMemberHistory.LeaveTime != ''
+								OR ChannelMemberHistory.JoinTime < ChannelMemberHistory.LeaveTime
+							THEN 1
+							ELSE 0
+					END AS 'HasLeftGroup'
+
+					FROM  ChannelMemberHistory
+
+					WHERE ChannelMemberHistory.ChannelID = Channels.Id
+					AND ChannelMemberHistory.UserID = :userId
+					ORDER BY ChannelMemberHistory.JoinTime DESC
+					LIMIT 1
+				) AS 'HasLeftGroup'
+
+
+				    FROM Channels
+
+				WHERE Channels.TeamID = :teamId
+				AND Channels.Type = 'P'
+				AND
+				(` + prefixFilterQuery + `)
+			`
+		var userTeams []*model.LearningGroup
+
+		if _, err := us.GetReplica().Select(&userTeams, query, map[string]interface{}{"userId": userId, "teamId": teamId}); err != nil {
+			result.Err = model.NewAppError("SqlUserStore.GetLearningGroups", "store.sql_post.get_user_teams.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		result.Data = userTeams
 	})
 }

--- a/store/store.go
+++ b/store/store.go
@@ -283,6 +283,8 @@ type UserStore interface {
 	ClearAllCustomRoleAssignments() StoreChannel
 	InferSystemInstallDate() StoreChannel
 	GetAllAfter(limit int, afterId string) StoreChannel
+	GetUserInteractions(userId string, teamId string, learningGroupTypes []*model.LearningGroupType) StoreChannel
+	GetUserLearningGroups(userId string, teamId string, learningGroupTypes []*model.LearningGroupType) StoreChannel
 }
 
 type SessionStore interface {

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -848,3 +848,35 @@ func (_m *UserStore) VerifyEmail(userId string) store.StoreChannel {
 
 	return r0
 }
+
+// GetUserInteractions provides a mock function with given fields: uid, teamId, learningGroupTypes
+func (_m *UserStore) GetUserInteractions(uid string, teamId string, learningGroupTypes []*model.LearningGroupType) store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// GetUserTeams provides a mock function with given fields: uid, teamId, learningGroupTypes
+func (_m *UserStore) GetUserLearningGroups(uid string, teamId string, learningGroupTypes []*model.LearningGroupType) store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}


### PR DESCRIPTION
#### Summary
This pull request contains changes made to the server to accommodate requests from the front-end for user interactions data.

**api4/user.go**
- Added api get route ‘users/{userId}/teams/{teamId}/useranalytics‘
    - Requires 1 parameter 
       - name: a string indicating the data set that you want to fetch. The names of data sets are defined in mattermost-redux/src/constants/user_analytics.js (Datasets)

- Added function getUserAnalytics() to handle route
    - Calls app/user.go and eventually returns data to mattermost-redux

**app/user.go**
- Added GetUserAnalytics() function, which calls to the service layer and runs the sql queries, appends the data to a UserAnalytics struct, and finally returns all data back to api4/user.go
    - Currently the only data set that can be explicitly requested is 'UserInteractions'
    - 'UserLearningGroups' data is always returned in the request
    - 'LearningGroupPrefixes' data is always returned in the request
- Added GetLearningGroupPrefixes() function, which given a teamId:
    1. gets data for the current team (most importantly, the slug name)
    2. finds the LMS in the config that has a team defined with that slug name
    3. returns the learning group prefixes for that LMS (using the GetLearningGroupPrefixes utility function in model/edx.go)

**model/edx.go**
- Added GetTeams() function, which given a learning management service object (LMS), returns the teams and their slug names from the config file
- Added GetLearningGroupPrefixes() function, which given a learning management service object (LMS), returns the keys to the ChannelList object in that LMS
- Added CheckIfActiveLMS() function, which given a learning management service object (LMS) and team slug, determines if that team slug exists in the LMS, which indicates that the LMS is the active LMS 

**store/sqlstore/user_store.go**
- Added GetUserInteractions() function, which runs sql query and returns data back to app/user.go
    - User interaction data is returned as an array of pointers to UserInteraction structs, where each struct represents a single user interaction. The struct is defined in (/model/user.go), with the following properties:
        - _Interaction_type_
            - ‘Reaction’
            - ‘Mention’
            - ‘Reply’
            - ‘DirectMessage'
        - _Username_
            - Username of the other user in a row’s interaction
            - Could be the recipient or the creator of a row’s interaction
        - _Is_Recipient_	
            - Boolean denoting whether the current user is the recipient of a row’s interaction
        - _Context_
            - ‘Course’
        - _Channel.Type_ 
            - Useful for debugging and implementation on front-end
            -Will be a char, denoting the type of channel that the interaction took place in, one of:
                - P -private channel
                - D -direct message
                - G -group message
                - O -public channel
        - _Channel.Name_ 
            - Useful for debugging and implementation on front-end
            - The name of the channel that the interaction took place in (ex. town-square)
- Added GetUserLearningGroups() function, which runs sql query and returns data back to app/user.go
    - User learning group data is returned as an array of pointers to LearningGroup structs, with a struct for each learning group that the user is a member of (ex. PLG or Capstone). The struct is defined in (/model/user.go), with the following columns:
        - _Channel_Id_
            - id of the channel for this team
        - _Channel_Name_
            - name of the channel for this team (ex. plg-30)
        - _Members_
            - a comma delimited list of the usernames of the users that are in this team's channel
        - _Team_Name_
            - the Channel_Name without the initial team type (ex. plg-30 => '30')
        - _Team_Type_
            - the type of team (ex. plg-30 => 'plg')
       - _Has_Left_Group_
           - bool denoting whether or not the user has left his learning group

**store/storetest/mocks/UserStore.go**
_Need to look further into how/why these are used...the console had an error if this wasn’t present. They map to functions in 'store/sqlstore/user_store.go'_
- Added GetUserInteractions() function, which is a mock function for mattermost tests
- Also added GetUserLearningGroups() function, for same reason

#### Ticket Link
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/101