### PR TITLE
Fixed bug in GetUserLearningGroups sql query

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1811,8 +1811,11 @@ func (us *SqlUserStore) GetUserLearningGroups(userId string, teamId string, lear
 					LIMIT 1
 				) AS 'HasLeftGroup'
 
-
 				    FROM Channels
+
+						JOIN ChannelMemberHistory
+						ON ChannelMemberHistory.UserID = :userId
+						AND ChannelMemberHistory.ChannelID = Channels.Id
 
 				WHERE Channels.TeamID = :teamId
 				AND Channels.Type = 'P'


### PR DESCRIPTION
#### Summary
The sql query was trying to get the column 'HasLeftGroup' for groups that the user was never a member of. Joining on ChannelMemberHistory explicitly fixed this.
