### PR TITLE
LearningGroup.Members is now an array of LearningGroupMember objects

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -19,6 +19,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -1748,6 +1749,11 @@ func (a *App) GetLearningGroupTypes(teamId string) ([]*model.LearningGroupType, 
 			}
 		}
 	}
+
+	// Sort the learning group types by prefix so the same set of types is always returned in the same order
+	sort.Slice(learningGroupTypes[:], func(i, j int) bool {
+		return learningGroupTypes[i].Prefix < learningGroupTypes[j].Prefix
+	})
 
 	return learningGroupTypes, nil
 }

--- a/app/user.go
+++ b/app/user.go
@@ -1688,13 +1688,51 @@ func (a *App) GetUserAnalytics(userId string, teamId string, name string) (*mode
 	}
 
 	// Always return the user's learning groups
-	if userLearningGroups := <-a.Srv.Store.User().GetUserLearningGroups(userId, teamId, learningGroupTypes); userLearningGroups.Err != nil {
+	userLearningGroupsQueryResult := <-a.Srv.Store.User().GetUserLearningGroups(userId, teamId, learningGroupTypes)
+	if userLearningGroupsQueryResult.Err != nil {
 		// Return and exit from GetUserAnalytics with error
-		return nil, userLearningGroups.Err
+		return nil, userLearningGroupsQueryResult.Err
 	} else {
+
+		userLearningGroupsQueryRows := userLearningGroupsQueryResult.Data.([]*model.LearningGroupQueryRow)
+		var userLearningGroups []*model.LearningGroup = make([]*model.LearningGroup, len(userLearningGroupsQueryRows))
+
+		//mlog.Debug("GetUserAnalytics: user learning groups", mlog.Any("userLearningGroupsQueryRows", userLearningGroupsQueryRows))
+
+		// Loop over learning group query rows and create a learning group for each
+		// Also, for each learning group, if it has members, create LearningGroupMember structs for each member
+		// Note: in a learning group query row, members is a double delimited string of users (; delimited) and
+		// each user's id and username (, delimited)
+
+		for i, userLearningGroupQueryRow := range userLearningGroupsQueryRows {
+			userLearningGroup := model.LearningGroup{
+				LearningGroupName:   userLearningGroupQueryRow.LearningGroupName,
+				LearningGroupPrefix: userLearningGroupQueryRow.LearningGroupPrefix,
+				ChannelId:           userLearningGroupQueryRow.ChannelId,
+				ChannelSlugName:     userLearningGroupQueryRow.ChannelSlugName,
+				ChannelDisplayName:  userLearningGroupQueryRow.ChannelDisplayName,
+				HasLeftGroup:        userLearningGroupQueryRow.HasLeftGroup,
+			}
+			userLearningGroups[i] = &userLearningGroup
+
+			if userLearningGroupQueryRow.Members == nil {
+				continue
+			}
+
+			usersInLearningGroup := strings.Split(*userLearningGroupQueryRow.Members, ";")
+			membersArray := make([]model.LearningGroupMember, len(usersInLearningGroup))
+
+			for j, user := range usersInLearningGroup {
+				userData := strings.Split(user, ",")
+				membersArray[j] = model.LearningGroupMember{Id: userData[0], Username: userData[1]}
+			}
+
+			userLearningGroups[i].Members = membersArray
+		}
+
 		// Add LearningGroups data to the returnData object
 		// Assert as type 'array of pointers to LearningGroup structs'
-		if returnData.UserLearningGroups, assertionSuccess = userLearningGroups.Data.([]*model.LearningGroup); !assertionSuccess {
+		if returnData.UserLearningGroups, assertionSuccess = interface{}(userLearningGroups).([]*model.LearningGroup); !assertionSuccess {
 			// Return and exit from GetUserAnalytics with error
 			return nil, model.NewAppError("GetUserAnalytics", "api.user.get_user_analytics.learning_group_assertion_error", nil, "", http.StatusBadRequest)
 		}

--- a/model/user.go
+++ b/model/user.go
@@ -96,7 +96,6 @@ type UserAnalytics struct {
 }
 
 // This is a struct for a learning group (ex. capstone)
-// **Note: Using pointers as property types allows for null values
 type LearningGroup struct {
 	// The name of the learning group (the channel name minus the learning group type's prefix)
 	//     ex. plg-30 => 30
@@ -115,11 +114,48 @@ type LearningGroup struct {
 	// The display name of the private channel for this learning group (Channels.DisplayName)
 	ChannelDisplayName string `json:"channel_display_name"`
 
-	// A comma delimited list of the usernames of the members of this learning group (channel)
+	// An array of LearningGroupMember structs for every member of this learning group (channel)
+	Members []LearningGroupMember `json:"members"`
+
+	// Denotes whether or not the current user has left this learning group
+	HasLeftGroup bool `json:"has_left_group"`
+}
+
+// This is a struct for a learning group query row (ex. capstone)
+// **Note: Using pointers as property types allows for null values
+type LearningGroupQueryRow struct {
+	// The name of the learning group (the channel name minus the learning group type's prefix)
+	//     ex. plg-30 => 30
+	LearningGroupName string `json:"learning_group_name"`
+
+	// The prefix for this learning group type (personal channel name from the config)
+	//     ex. plg
+	LearningGroupPrefix string `json:"learning_group_prefix"`
+
+	// The id of the private channel for this learning group
+	ChannelId string `json:"channel_id"`
+
+	// The slug name of the private channel for this learning group (Channels.Name)
+	ChannelSlugName string `json:"channel_slug_name"`
+
+	// The display name of the private channel for this learning group (Channels.DisplayName)
+	ChannelDisplayName string `json:"channel_display_name"`
+
+	// A semicolor (;) delimited string of members of this learning group channel where each
+	// member string consists of the member's id and username separated by a comma (,).
 	Members *string `json:"members"`
 
 	// Denotes whether or not the current user has left this learning group
 	HasLeftGroup bool `json:"has_left_group"`
+}
+
+// A struct for a member of a learning group
+type LearningGroupMember struct {
+	// The id of this member (user)
+	Id string `json:"id"`
+
+	// The username of this member (user)
+	Username string `json:"username"`
 }
 
 type User struct {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1823,7 +1823,11 @@ func (us *SqlUserStore) GetUserLearningGroups(userId string, teamId string, lear
 				Channels.Name AS 'ChannelSlugName',
 				Channels.DisplayName AS 'ChannelDisplayName',
 				(
-				SELECT GROUP_CONCAT(Users.Username)
+				SELECT GROUP_CONCAT(
+									CONCAT(Users.id,',',Users.Username)
+									SEPARATOR ';'
+								)
+
 				    FROM Users
 				WHERE Users.Id IN (SELECT UserId
                                FROM ChannelMembers CM
@@ -1859,7 +1863,7 @@ func (us *SqlUserStore) GetUserLearningGroups(userId string, teamId string, lear
 				AND
 				(` + prefixFilterQuery + `)
 			`
-		var userTeams []*model.LearningGroup
+		var userTeams []*model.LearningGroupQueryRow
 
 		if _, err := us.GetReplica().Select(&userTeams, query, map[string]interface{}{"userId": userId, "teamId": teamId}); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetLearningGroups", "store.sql_post.get_user_teams.app_error", nil, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
#### Summary
It will be useful to have an array of learning group member objects for each learning group (LearningGroup.Members), so as to have access to both the username and id of each member. This is in part inspired by requirements of the recommendations feature, but it also a better format to return the data in overall. 
