### PR TITLE
Posts are interactions

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -56,7 +56,8 @@ type UserInteraction struct {
 	InteractionType string `json:"interaction_type"`
 
 	// The username of the user that this interaction took place with
-	Username string `json:"username"`
+	// Use pointer because interactions of type 'Post' will not have a corresponding username
+	Username *string `json:"username"`
 
 	// Denotes whether or not the current user was the recipient of this interaction
 	IsRecipient bool `json:"is_recipient"`

--- a/model/user.go
+++ b/model/user.go
@@ -74,7 +74,7 @@ type UserInteraction struct {
 	ChannelType string `json:"channel_type"`
 
 	// The slug name of the channel that this interaction took place in (Channels.Name)
-	ChannelName string `json:"channel_name"`
+	ChannelSlugName string `json:"channel_slug_name"`
 }
 
 // This is a struct for a learning group type
@@ -110,7 +110,10 @@ type LearningGroup struct {
 	ChannelId string `json:"channel_id"`
 
 	// The slug name of the private channel for this learning group (Channels.Name)
-	ChannelName string `json:"channel_name"`
+	ChannelSlugName string `json:"channel_slug_name"`
+
+	// The slug name of the private channel for this learning group (Channels.Name)
+	ChannelDisplayName string `json:"channel_display_name"`
 
 	// A comma delimited list of the usernames of the members of this learning group (channel)
 	Members *string `json:"members"`

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1400,7 +1400,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 
 				END AS 'Context',
 				Channels.Type AS 'ChannelType',
-				Channels.Name AS 'ChannelName'
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName'
 
 				    FROM Reactions
 
@@ -1430,7 +1431,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 
 				END AS 'Context',
 				Channels.Type AS 'ChannelType',
-				Channels.Name AS 'ChannelName'
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName'
 
 				    FROM Reactions
 
@@ -1474,7 +1476,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 
 				END AS 'Context',
 				Channels.Type AS 'ChannelType',
-				Channels.Name AS 'ChannelName'
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName'
 
 				    FROM Users Mentionee
 
@@ -1518,7 +1521,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 
 				END AS 'Context',
 				Channels.Type AS 'ChannelType',
-				Channels.Name AS 'ChannelName'
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName'
 
 				  FROM Posts Reply
 
@@ -1561,7 +1565,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 				END AS 'IsRecipient',
 				'course' AS 'Context',
 				Channels.Type AS 'ChannelType',
-				Channels.Name AS 'ChannelName'
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName'
 
 				    FROM Posts
 
@@ -1625,7 +1630,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 				END AS 'IsRecipient',
 				'course' AS 'Context',
 				ChannelType,
-				ChannelName
+				ChannelSlugName,
+				ChannelDisplayName
 
 				    FROM ChannelMembers
 
@@ -1646,7 +1652,9 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 					        ParentPostAuthor.Id AS 'Parent_Post_Author_Id',
 					        Posts.Id AS 'PostId',
 					        Channels.Type AS 'ChannelType',
-					        Channels.Name AS 'ChannelName'
+					        Channels.Name AS 'ChannelSlugName',
+									Channels.DisplayName AS 'ChannelDisplayName'
+
 
 					            FROM Posts
 
@@ -1709,7 +1717,8 @@ func (us *SqlUserStore) GetUserInteractions(userId string, teamId string, learni
 
 				END AS 'Context',
 				Channels.Type AS 'ChannelType',
-				Channels.Name AS 'ChannelName'
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName'
 
 				    FROM Posts
 
@@ -1811,7 +1820,8 @@ func (us *SqlUserStore) GetUserLearningGroups(userId string, teamId string, lear
 				` + prefixQuery + `
 				END AS 'LearningGroupPrefix',
 				Channels.Id AS 'ChannelId',
-				Channels.Name AS 'ChannelName',
+				Channels.Name AS 'ChannelSlugName',
+				Channels.DisplayName AS 'ChannelDisplayName',
 				(
 				SELECT GROUP_CONCAT(Users.Username)
 				    FROM Users


### PR DESCRIPTION
#### Summary
The GetUserInteractions sql query was modified to return rows for Posts in public and private channels. Each of these rows will have a username of null, and an interaction type of 'Post'.

Additionally, channel display names are also returned now. The json key for the slug name on the front-end will now be 'channel_slug_name', and as such, the front-end PR (soon to be posted) 'feature/posts-are-interactions', works in congruence with this PR.

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/163
