### PR TITLE
LTI login does not require the session and the CSRF check can be skipped

### DIFF
--- a/web/lti.go
+++ b/web/lti.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (w *Web) InitLti() {
-	w.MainRouter.Handle("/login/lti", w.NewHandler(loginWithLTI)).Methods("POST")
+	w.MainRouter.Handle("/login/lti", w.ApiHandlerTrustRequester(loginWithLTI)).Methods("POST")
 }
 
 func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Summary
The functionality to prevent cross site request forgeries was implemented in Mattermost after the LTI functionality was originally implemented. It is now necessary to let the mattermost server know that the PUSH request to the endpoint that performs an LTI login/signup is trusted so it will skip the CSRF check.

### Ticket Link
fixes #28 Logging in via LTI gets Error page "Invalid or expired session"

### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style`
