### PR TITLE
Support generic edx LTI w/o a platform-wide user id field

### DIFF
--- a/app/lti.go
+++ b/app/lti.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -137,7 +136,7 @@ func (a *App) joinChannelsIfRequired(userId string, channels model.ChannelList) 
 			// channel member doesn't exist
 			// add user to channel
 			if _, err := a.AddChannelMember(userId, channel, "", ""); err != nil {
-				mlog.Error(fmt.Sprintf("User with ID %s could not be added to channel with ID %s. Error: %s", userId, channel.Id, err.Error()))
+				mlog.Error("User could not be added to channel: "+err.Error(), mlog.String("UserId", userId), mlog.String("ChannelId", channel.Id))
 				continue
 			}
 		}
@@ -147,14 +146,14 @@ func (a *App) joinChannelsIfRequired(userId string, channels model.ChannelList) 
 func (a *App) addTeamMemberIfRequired(userId string, teamName string) *model.AppError {
 	team, err := a.GetTeamByName(teamName)
 	if err != nil {
-		mlog.Error(fmt.Sprintf("Team to be used: %s could not be found: %s", teamName, err.Error()))
+		mlog.Error("Team to be used could not be found: "+err.Error(), mlog.String("TeamName", teamName))
 		return model.NewAppError("OnboardLTIUser", "app.onboard_lms_user.team_not_found.app_error", nil, "", http.StatusInternalServerError)
 	}
 
 	if _, err := a.GetTeamMember(team.Id, userId); err != nil {
 		// user is not a member of team. Adding team member
 		if _, err := a.AddTeamMember(team.Id, userId); err != nil {
-			mlog.Error(fmt.Sprintf("Error occurred while adding user %s to team %s: %s", userId, team.Id, err.Error()))
+			mlog.Error("Error occurred while adding user to team: "+err.Error(), mlog.String("UserId", userId), mlog.String("TeamId", team.Id))
 		}
 	}
 

--- a/config/config-dev.json
+++ b/config/config-dev.json
@@ -1,6 +1,6 @@
 {
     "ServiceSettings": {
-        "SiteURL": "http://localhost",
+        "SiteURL": "https://localhost",
         "WebsocketURL": "",
         "LicenseFileLocation": "",
         "ListenAddress": ":8065",
@@ -550,7 +550,7 @@
     },
     "PluginSettings": {
         "Enable": true,
-        "EnableUploads": false,
+        "EnableUploads": true,
         "AllowInsecureDownloadUrl": false,
         "EnableHealthCheck": true,
         "Directory": "./plugins",
@@ -561,7 +561,7 @@
                 "Enable": true
             }
         },
-        "EnableMarketplace": true,
+        "EnableMarketplace": false,
         "EnableRemoteMarketplace": true,
         "AutomaticPrepackagedPlugins": true,
         "RequirePluginSignature": false,

--- a/model/edx_test.go
+++ b/model/edx_test.go
@@ -55,6 +55,15 @@ func TestBuildUser(t *testing.T) {
 	assert.Equal(t, "password", user.Password)
 	assert.Contains(t, user.Props, "lti_user_id")
 	assert.Equal(t, "user_5", user.Props["lti_user_id"])
+
+	// Test BuildUser w/o a custom_user_id field in the launchData
+	// should compose an lti_user_id w/ the consumer key and user's email
+	delete(launchData, "custom_user_id")
+	user, err = lms.BuildUser(launchData, "password")
+	assert.Nil(t, err)
+
+	assert.Contains(t, user.Props, "lti_user_id")
+	assert.Equal(t, "consumer_key:foo@example.com", user.Props["lti_user_id"])
 }
 
 func TestGetPrivateChannelsToJoin(t *testing.T) {

--- a/model/lti_test.go
+++ b/model/lti_test.go
@@ -52,9 +52,9 @@ func TestGetKnownLMSs(t *testing.T) {
 
 func TestGetLMSChannelSlug(t *testing.T) {
 	personalChannelName := "plg"
-	channelId := "really_long_personal_channel_id"
+	channelId := "really_long_personal_channel_id_34567890123456789012345678901234567890"
 	channelSlug := GetLMSChannelSlug(personalChannelName, channelId)
-	assert.Equal(t, "plg-really_long_person", channelSlug)
+	assert.Equal(t, "plg-really_long_personal_channel_id_3456789012345678901234567890", channelSlug)
 }
 
 func Test_baseValidateLTIRequest(t *testing.T) {


### PR DESCRIPTION
#### Summary
The current edX LTI signup/login implementation was coded with the Appsembler customized edX platform implementation. Appsembler sends a `custom_user_id` field in the LTI post containing a unique platform wide identifier for the user. This is because the standard LTI `user_id` field that is sent by the edX platform is course (context) specific.

This LMS user id is used in the Mattermost LTI authorization code to associate the MM user with the LMS user and verify that user for subsequent logins. This allows the other MM user information to be resynced with the user information sent with the LTI login POST, including the email address.

It is critical that a user of multiple courses on an edX platform be identified as the same user when they are signed in to the RiffEdu mattermost site from any of those courses.
- Users on an LMS may be in multiple courses (either as students or as instructors). The LTI authorization checks that the supplied email address is not used by a different LTI signon. That is considered an error. This requires that the LMS user id be LMS platform unique and not specific only to a single course.
- Multiple courses may have their students sharing a RiffEdu Team.
- A student should be able to easily switch Teams if they are taking multiple courses each with their own RiffEdu Team. 


The new design will use the `custom_user_id` field if it exists. However if it doesn't exist, an LMS platform user id will be constructed from the consumer key identifying that LMS and the user's email address.

This fallback user id is not as robust as using the a unique platform id supplied by the LMS. In particular if the LMS user changes their email, Mattermost (RiffEdu) will consider them a new user and there will be no association with their previous user w/ the old email address.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
