### PR TITLE
Mark user's emails as verified if joining from LTI launch

### DIFF
--- a/api4/lti.go
+++ b/api4/lti.go
@@ -70,6 +70,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user.EmailVerified = true
 	user, appErr = c.App.CreateUser(user)
 	if appErr != nil {
 		mlog.Error("Error occurred while creating LTI user: " + appErr.Error())


### PR DESCRIPTION
#### Summary
- Set user's email as verified when joining via an LTI launch.

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
