### PR TITLE
Make changes to read LTI Settings from LTI plugin config.

### DIFF
--- a/api4/lti.go
+++ b/api4/lti.go
@@ -23,7 +23,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	LTISettings, err := c.App.GetLTISettings();
 	if(err != nil){
 		mlog.Error(err.Error());
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.unmarshaling.app_error", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.get_lti_config.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -20,7 +20,14 @@ func (api *API) InitLTI() {
 }
 
 func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.Config().LTISettings.Enable {
+	LTISettings, err := c.App.GetLTISettings();
+	if(err != nil){
+		mlog.Error(err.Error());
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.unmarshaling.app_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !LTISettings.Enable {
 		mlog.Error("LTI signup request when LTI is disabled")
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
@@ -55,7 +62,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.Config().LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
+	if LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.validation.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/api4/lti.go
+++ b/api4/lti.go
@@ -20,9 +20,9 @@ func (api *API) InitLTI() {
 }
 
 func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
-	LTISettings, err := c.App.GetLTISettings();
-	if(err != nil){
-		mlog.Error(err.Error());
+	LTISettings, err := c.App.GetLTISettings()
+	if err != nil {
+		mlog.Error(err.Error())
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.get_lti_config.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -604,6 +604,7 @@ type AppIface interface {
 	GetJobsByTypePage(jobType string, page int, perPage int) ([]*model.Job, *model.AppError)
 	GetJobsPage(page int, perPage int) ([]*model.Job, *model.AppError)
 	GetLMSToUse(consumerKey string) model.LMS
+	GetLTISettings() (*model.LTISettings, error)
 	GetLatestTermsOfService() (*model.TermsOfService, *model.AppError)
 	GetLogs(page, perPage int) ([]string, *model.AppError)
 	GetLogsSkipSend(page, perPage int) ([]string, *model.AppError)

--- a/app/lti.go
+++ b/app/lti.go
@@ -4,15 +4,22 @@
 package app
 
 import (
-	"net/http"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 )
 
-func (a* App) GetLTISettings() (*model.LTISettings, error) {
+//
+//	GetLTISettings() reads the LTI Config from Plugin Config
+//
+func (a *App) GetLTISettings() (*model.LTISettings, error) {
+
+	//	Check that if a plugin with LTI_PLUGIN_ID is installed in the server.
 	var LTIConfig map[string]interface{}
 	LTIConfig, ok := a.Config().PluginSettings.Plugins[model.LTI_PLUGIN_ID]
 	if !ok {
@@ -21,20 +28,20 @@ func (a* App) GetLTISettings() (*model.LTISettings, error) {
 
 	configJson, err := json.Marshal(LTIConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling LTI Config: %s",err.Error())
+		return nil, errors.Wrap(err, "Error marshaling LTI Config: %s")
 	}
 
 	var LTISettings *model.LTISettings
 	if err = json.Unmarshal(configJson, &LTISettings); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling LTI Config from json: %s",err.Error())
+		return nil, errors.Wrap(err, "Error unmarshaling LTI Config from json: %s")
 	}
-	return LTISettings, nil;
+	return LTISettings, nil
 }
 
 func (a *App) GetLMSToUse(consumerKey string) model.LMS {
-	LTISettings, err := a.GetLTISettings();
-	if(err != nil){
-		mlog.Error(err.Error());
+	LTISettings, err := a.GetLTISettings()
+	if err != nil {
+		mlog.Error(err.Error())
 		return nil
 	}
 

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -6256,6 +6256,28 @@ func (a *OpenTracingAppLayer) GetLMSToUse(consumerKey string) model.LMS {
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) GetLTISettings() (*model.LTISettings, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetLTISettings")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetLTISettings()
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetLTIUser(ltiUserID string, email string) *model.User {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetLTIUser")

--- a/config/client.go
+++ b/config/client.go
@@ -252,8 +252,6 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 
 	props["EnableSignUpWithGitLab"] = strconv.FormatBool(*c.GitLabSettings.Enable)
 
-	props["EnableSignUpWithLTI"] = strconv.FormatBool(c.LTISettings.Enable)
-
 	props["TermsOfServiceLink"] = *c.SupportSettings.TermsOfServiceLink
 	props["PrivacyPolicyLink"] = *c.SupportSettings.PrivacyPolicyLink
 	props["AboutLink"] = *c.SupportSettings.AboutLink
@@ -310,6 +308,13 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["EnforceMultifactorAuthentication"] = "false"
 	props["EnableGuestAccounts"] = strconv.FormatBool(*c.GuestAccountsSettings.Enable)
 	props["GuestAccountsEnforceMultifactorAuthentication"] = strconv.FormatBool(*c.GuestAccountsSettings.EnforceMultifactorAuthentication)
+
+	props["EnableSignUpWithLTI"] = strconv.FormatBool(false)
+	if LTIConfig, ok := c.PluginSettings.Plugins[model.LTI_PLUGIN_ID]; ok {
+		if LTIEnabled, ok := LTIConfig["enable"].(bool); ok {
+			props["EnableSignUpWithLTI"] = strconv.FormatBool(LTIEnabled)
+		}
+	}
 
 	if license != nil {
 		if *license.Features.LDAP {

--- a/config/client.go
+++ b/config/client.go
@@ -310,7 +310,10 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["GuestAccountsEnforceMultifactorAuthentication"] = strconv.FormatBool(*c.GuestAccountsSettings.EnforceMultifactorAuthentication)
 
 	props["EnableSignUpWithLTI"] = strconv.FormatBool(false)
+
+	//	Check that if LTI Plugin is installed.
 	if LTIConfig, ok := c.PluginSettings.Plugins[model.LTI_PLUGIN_ID]; ok {
+		// Update EnableSignUpWithLTI prop to allow the webapp to check if signup with LTI is enabled.
 		if LTIEnabled, ok := LTIConfig["enable"].(bool); ok {
 			props["EnableSignUpWithLTI"] = strconv.FormatBool(LTIEnabled)
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1713,6 +1713,14 @@
     "translation": "LTI-25: LTI Launch Data is missing UserID."
   },
   {
+    "id": "api.lti.signup.get_lti_config.app_error",
+    "translation": "LTI-26: Unable to retrieve LTI Settings from Config."
+  },
+  {
+    "id": "web.lti.login.get_lti_config.app_error",
+    "translation": "LTI-27: Unable to retrieve LTI Settings from Config."
+  },
+  {
     "id": "api.marshal_error",
     "translation": "marshal error"
   },

--- a/model/config.go
+++ b/model/config.go
@@ -3070,7 +3070,6 @@ type Config struct {
 	SupportSettings           SupportSettings
 	AnnouncementSettings      AnnouncementSettings
 	ThemeSettings             ThemeSettings
-	LTISettings               LTISettings // telemetry: none
 	GitLabSettings            SSOSettings
 	GoogleSettings            SSOSettings
 	Office365Settings         Office365Settings

--- a/model/lti.go
+++ b/model/lti.go
@@ -22,6 +22,8 @@ const (
 	LTI_NAME_COOKIE = "MMLTINAME"
 
 	LTI_USER_ID_PROP_KEY = "lti_user_id"
+
+	LTI_PLUGIN_ID = "com.rifflearning.lti"
 )
 
 type LMSOAuthSettings struct {
@@ -48,9 +50,9 @@ type LMS interface {
 }
 
 type LTISettings struct {
-	Enable                    bool
-	EnableSignatureValidation bool
-	LMSs                      []interface{}
+	Enable                    bool          `json:"enable"`
+	EnableSignatureValidation bool          `json:"enablesignaturevalidation"`
+	LMSs                      []interface{} `json:"lmss"`
 }
 
 // GetKnownLMSs can be used to extract a slice of known LMSs from LTI settings

--- a/model/lti.go
+++ b/model/lti.go
@@ -23,6 +23,7 @@ const (
 
 	LTI_USER_ID_PROP_KEY = "lti_user_id"
 
+	// LTI_PLUGIN_ID is the ID of the plugin used to maintain the LTI settings.
 	LTI_PLUGIN_ID = "com.rifflearning.lti"
 )
 

--- a/web/lti.go
+++ b/web/lti.go
@@ -21,15 +21,14 @@ func (w *Web) InitLti() {
 
 func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	mlog.Debug("Received an LTI Login request")
-
-	LTISettings, ltiErr := c.App.GetLTISettings();
-	if(ltiErr != nil){
-		mlog.Error(ltiErr.Error());
+	LTISettings, ltiErr := c.App.GetLTISettings()
+	if ltiErr != nil {
+		mlog.Error(ltiErr.Error())
 		c.Err = model.NewAppError("signupWithLTI", "web.lti.login.get_lti_config.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(LTISettings.Enable))
-	
+
 	if !LTISettings.Enable {
 		mlog.Error("LTI login request when LTI is disabled in config.json")
 		c.Err = model.NewAppError("loginWithLTI", "web.lti.login.disabled.app_error", nil, "", http.StatusNotImplemented)

--- a/web/lti.go
+++ b/web/lti.go
@@ -25,7 +25,7 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	LTISettings, ltiErr := c.App.GetLTISettings();
 	if(ltiErr != nil){
 		mlog.Error(ltiErr.Error());
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.marshaling.app_error", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("signupWithLTI", "web.lti.login.get_lti_config.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(LTISettings.Enable))

--- a/web/lti_test.go
+++ b/web/lti_test.go
@@ -19,17 +19,18 @@ func TestLoginWithLTI(t *testing.T) {
 	defer th.TearDown()
 
 	pluginJson := map[string]interface{}{
-		"enable": false,
+		"enable":                    false,
 		"enablesignaturevalidation": true,
-		"lmss": nil,
+		"lmss":                      nil,
 	}
 
+	// Add the LTI plugin settings in the testing config.
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		cfg.PluginSettings.Plugins[model.LTI_PLUGIN_ID] = pluginJson
 	})
 
-	LTISettings, ltiErr := th.App.GetLTISettings();
-	if(ltiErr != nil){
+	LTISettings, ltiErr := th.App.GetLTISettings()
+	if ltiErr != nil {
 		require.Nil(t, ltiErr)
 		return
 	}

--- a/web/lti_test.go
+++ b/web/lti_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattermost/mattermost-server/v5/model"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,14 +18,23 @@ func TestLoginWithLTI(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
+	pluginJson := map[string]interface{}{
+		"enable": false,
+		"enablesignaturevalidation": true,
+		"lmss": nil,
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.PluginSettings.Plugins[model.LTI_PLUGIN_ID] = pluginJson
+	})
+
 	LTISettings, ltiErr := th.App.GetLTISettings();
 	if(ltiErr != nil){
 		require.Nil(t, ltiErr)
 		return
 	}
 
-	// TODO: Fix test failing here because now we are getting LTISettings from plugin config.
-	if !th.App.Config().LTISettings.Enable {
+	if !LTISettings.Enable {
 		resp, err := http.Post(ApiClient.Url+"/login/lti", "", strings.NewReader("123"))
 		require.Nil(t, err)
 		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - lti turned off")

--- a/web/lti_test.go
+++ b/web/lti_test.go
@@ -16,6 +16,13 @@ func TestLoginWithLTI(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
+	LTISettings, ltiErr := th.App.GetLTISettings();
+	if(ltiErr != nil){
+		require.Nil(t, ltiErr)
+		return
+	}
+
+	// TODO: Fix test failing here because now we are getting LTISettings from plugin config.
 	if !th.App.Config().LTISettings.Enable {
 		resp, err := http.Post(ApiClient.Url+"/login/lti", "", strings.NewReader("123"))
 		require.Nil(t, err)


### PR DESCRIPTION
#### Summary
Make changes to read LTI Settings from [LTI plugin](https://github.com/Brightscout/mattermost-plugin-riff-lti) config. This has the following advantages over the existing implementation:
 - System Admins can easily add/update/remove the LMS configuration.
 - Admins don't need to restart the server for every configuration change.
  
#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/rifflearning/mattermost-server/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
