### PR TITLE
Move LTI configuration settings location in config.json to PluginSettings

### DIFF
--- a/api4/lti.go
+++ b/api4/lti.go
@@ -20,7 +20,14 @@ func (api *API) InitLTI() {
 }
 
 func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.Config().LTISettings.Enable {
+	LTISettings, err := c.App.GetLTISettings()
+	if err != nil {
+		mlog.Error(err.Error())
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.get_lti_config.app_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !LTISettings.Enable {
 		mlog.Error("LTI signup request when LTI is disabled")
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
@@ -55,7 +62,7 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.Config().LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
+	if LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+"/login/lti", addLaunchDataToForm(ltiLaunchData, r)) {
 		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.validation.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -34,6 +34,10 @@ import (
 
 // AppIface is extracted from App struct and contains all it's exported methods. It's provided to allow partial interface passing and app layers creation.
 type AppIface interface {
+	//
+	//	GetLTISettings() reads the LTI Config from Plugin Config
+	//
+	GetLTISettings() (*model.LTISettings, error)
 	// @openTracingParams args
 	ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError)
 	// @openTracingParams teamID

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -6256,6 +6256,28 @@ func (a *OpenTracingAppLayer) GetLMSToUse(consumerKey string) model.LMS {
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) GetLTISettings() (*model.LTISettings, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetLTISettings")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetLTISettings()
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetLTIUser(ltiUserID string, email string) *model.User {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetLTIUser")

--- a/config/client.go
+++ b/config/client.go
@@ -252,8 +252,6 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 
 	props["EnableSignUpWithGitLab"] = strconv.FormatBool(*c.GitLabSettings.Enable)
 
-	props["EnableSignUpWithLTI"] = strconv.FormatBool(c.LTISettings.Enable)
-
 	props["TermsOfServiceLink"] = *c.SupportSettings.TermsOfServiceLink
 	props["PrivacyPolicyLink"] = *c.SupportSettings.PrivacyPolicyLink
 	props["AboutLink"] = *c.SupportSettings.AboutLink
@@ -310,6 +308,16 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["EnforceMultifactorAuthentication"] = "false"
 	props["EnableGuestAccounts"] = strconv.FormatBool(*c.GuestAccountsSettings.Enable)
 	props["GuestAccountsEnforceMultifactorAuthentication"] = strconv.FormatBool(*c.GuestAccountsSettings.EnforceMultifactorAuthentication)
+
+	props["EnableSignUpWithLTI"] = strconv.FormatBool(false)
+
+	// Check if the LTISettings configuration exists, it "belongs" to the LTI_PLUGIN_ID plugin.
+	if LTIConfig, ok := c.PluginSettings.Plugins[model.LTI_PLUGIN_ID]; ok {
+		// Update EnableSignUpWithLTI prop to allow the webapp to check if signup with LTI is enabled.
+		if LTIEnabled, ok := LTIConfig["enable"].(bool); ok {
+			props["EnableSignUpWithLTI"] = strconv.FormatBool(LTIEnabled)
+		}
+	}
 
 	if license != nil {
 		if *license.Features.LDAP {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1713,6 +1713,14 @@
     "translation": "LTI-25: LTI Launch Data is missing UserID."
   },
   {
+    "id": "api.lti.signup.get_lti_config.app_error",
+    "translation": "LTI-26: Unable to retrieve LTI Settings from Config."
+  },
+  {
+    "id": "web.lti.login.get_lti_config.app_error",
+    "translation": "LTI-27: Unable to retrieve LTI Settings from Config."
+  },
+  {
     "id": "api.marshal_error",
     "translation": "marshal error"
   },

--- a/model/config.go
+++ b/model/config.go
@@ -3070,7 +3070,6 @@ type Config struct {
 	SupportSettings           SupportSettings
 	AnnouncementSettings      AnnouncementSettings
 	ThemeSettings             ThemeSettings
-	LTISettings               LTISettings // telemetry: none
 	GitLabSettings            SSOSettings
 	GoogleSettings            SSOSettings
 	Office365Settings         Office365Settings

--- a/model/lti.go
+++ b/model/lti.go
@@ -22,6 +22,9 @@ const (
 	LTI_NAME_COOKIE = "MMLTINAME"
 
 	LTI_USER_ID_PROP_KEY = "lti_user_id"
+
+	// LTI_PLUGIN_ID is the ID of the plugin used to maintain the LTI settings.
+	LTI_PLUGIN_ID = "ai.riffanalytics.lti"
 )
 
 type LMSOAuthSettings struct {
@@ -48,9 +51,9 @@ type LMS interface {
 }
 
 type LTISettings struct {
-	Enable                    bool
-	EnableSignatureValidation bool
-	LMSs                      []interface{}
+	Enable                    bool          `json:"enable"`
+	EnableSignatureValidation bool          `json:"enablesignaturevalidation"`
+	LMSs                      []interface{} `json:"lmss"`
 }
 
 // GetKnownLMSs can be used to extract a slice of known LMSs from LTI settings

--- a/web/lti.go
+++ b/web/lti.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -21,9 +20,14 @@ func (w *Web) InitLti() {
 
 func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	mlog.Debug("Received an LTI Login request")
+	LTISettings, ltiErr := c.App.GetLTISettings()
+	if ltiErr != nil {
+		mlog.Error(ltiErr.Error())
+		c.Err = model.NewAppError("signupWithLTI", "web.lti.login.get_lti_config.app_error", nil, "", http.StatusNotImplemented)
+		return
+	}
 
-	mlog.Debug("Testing whether LTI is enabled: " + strconv.FormatBool(c.App.Config().LTISettings.Enable))
-	if !c.App.Config().LTISettings.Enable {
+	if !LTISettings.Enable {
 		mlog.Error("LTI login request when LTI is disabled in config.json")
 		c.Err = model.NewAppError("loginWithLTI", "web.lti.login.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
@@ -35,7 +39,7 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mlog.Debug("Validate LTI request. LTI Signature Validation enabled: " + strconv.FormatBool(c.App.Config().LTISettings.EnableSignatureValidation))
+	mlog.Debug("Validating LTI request if LTI Signature Validation is enabled", mlog.Bool("EnableSignatureValidation", LTISettings.EnableSignatureValidation))
 	consumerKey := r.FormValue("oauth_consumer_key")
 	lms := c.App.GetLMSToUse(consumerKey)
 	if lms == nil {
@@ -43,7 +47,7 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.Config().LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.App.Path(), r) {
+	if LTISettings.EnableSignatureValidation && !lms.ValidateLTIRequest(c.GetSiteURLHeader()+c.App.Path(), r) {
 		c.Err = model.NewAppError("loginWithLTI", "web.lti.login.validation.app_error", nil, "", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
_PR to merge cherrypicked/squashed commits from PR #32 (that commit is replaced with this one, but the discussions happened there)_

### Summary
Make changes to read LTI Settings from [LTI plugin](https://github.com/Brightscout/mattermost-plugin-riff-lti) config. This has the following advantages over the existing implementation:
 - System Admins can easily add/update/remove the LMS configuration.
 - Admins don't need to restart the server for every configuration change.
  
### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/rifflearning/mattermost-server/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
