### PR TITLE
Fix LTI login by email

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -713,7 +713,7 @@ type AppIface interface {
 	GetUserAccessTokensForUser(userID string, page, perPage int) ([]*model.UserAccessToken, *model.AppError)
 	GetUserByAuth(authData *string, authService string) (*model.User, *model.AppError)
 	GetUserByEmail(email string) (*model.User, *model.AppError)
-	GetUserByLTI(ltiUserID string) (*model.User, error)
+	GetUserByLTI(ltiUserID string) (*model.User, *model.AppError)
 	GetUserByUsername(username string) (*model.User, *model.AppError)
 	GetUserForLogin(id, loginId string) (*model.User, *model.AppError)
 	GetUserTermsOfService(userID string) (*model.UserTermsOfService, *model.AppError)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -8909,7 +8909,7 @@ func (a *OpenTracingAppLayer) GetUserByEmail(email string) (*model.User, *model.
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetUserByLTI(ltiUserID string) (*model.User, error) {
+func (a *OpenTracingAppLayer) GetUserByLTI(ltiUserID string) (*model.User, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetUserByLTI")
 

--- a/web/lti.go
+++ b/web/lti.go
@@ -54,7 +54,6 @@ func loginWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	user := c.App.GetLTIUser(ltiUserID, email)
 	if user == nil {
 		// Case: MM or LTI User not found
-		mlog.Debug("MM or LTI User not found")
 		c.Logout(w, r)
 
 		// Don't redirect to signup page if BuildUser is going to fail


### PR DESCRIPTION
### Summary
Version `5.34.2-riff.0` had a bug where if an LTI login was attempted by a user where there was no user with the given LTI ID, but there was a user with the given email address, that user would not be returned by `GetLTIUser` causing the LTI user signup page to be presented, which would subsequently fail because a user with that email address did actually exist.

What is expected to happen is that GetLTIUser would return the user identified by the given email and then add the LTI ID to that user's Props.

This seems to have been caused when the LTI code was ported from `riff/mods_5.29` and `GetUserByLTI` was not updated to return an `AppError` if it failed as the other `GetUser*` functions did. Modifying `GetUserByLTI` to return an AppError when it fails fixed the issue.

### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
